### PR TITLE
Use new sonatype publishing plugin

### DIFF
--- a/.github/workflows/publish-sonatype.yml
+++ b/.github/workflows/publish-sonatype.yml
@@ -30,7 +30,7 @@ jobs:
 
       - name: Publish to Sonatype
         run: |
-          ./gradlew publish --stacktrace
+          ./gradlew publishToMavenCentral --stacktrace -PmavenCentralUsername="$SONATYPE_USERNAME" -PmavenCentralPassword="$SONATYPE_PASSWORD"
         env:
           SONATYPE_USERNAME: ${{ secrets.LANG_SMITH_SONATYPE_USERNAME || secrets.SONATYPE_USERNAME }}
           SONATYPE_PASSWORD: ${{ secrets.LANG_SMITH_SONATYPE_PASSWORD || secrets.SONATYPE_PASSWORD }}

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,20 +1,6 @@
-plugins {
-    id("io.github.gradle-nexus.publish-plugin") version "1.1.0"
-}
 
 allprojects {
     group = "com.langsmith.api"
     version = "0.1.0-alpha.1" // x-release-please-version
 }
 
-nexusPublishing {
-    repositories {
-        sonatype {
-            nexusUrl.set(uri("https://s01.oss.sonatype.org/service/local/"))
-            snapshotRepositoryUrl.set(uri("https://s01.oss.sonatype.org/content/repositories/snapshots/"))
-
-            username.set(System.getenv("SONATYPE_USERNAME"))
-            password.set(System.getenv("SONATYPE_PASSWORD"))
-        }
-    }
-}

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -1,12 +1,16 @@
 plugins {
     `kotlin-dsl`
+    kotlin("jvm") version "1.9.22"
+    id("com.vanniktech.maven.publish") version "0.28.0"
 }
 
 repositories {
     gradlePluginPortal()
+    mavenCentral()
 }
 
 dependencies {
     implementation("com.diffplug.spotless:spotless-plugin-gradle:6.25.0")
     implementation("org.jetbrains.kotlin:kotlin-gradle-plugin:1.9.22")
+    implementation("com.vanniktech:gradle-maven-publish-plugin:0.28.0")
 }

--- a/buildSrc/src/main/kotlin/langsmith.java.gradle.kts
+++ b/buildSrc/src/main/kotlin/langsmith.java.gradle.kts
@@ -1,6 +1,9 @@
 import com.diffplug.gradle.spotless.SpotlessExtension
+import com.vanniktech.maven.publish.JavaLibrary
+import com.vanniktech.maven.publish.JavadocJar
+import com.vanniktech.maven.publish.MavenPublishBaseExtension
+import com.vanniktech.maven.publish.SonatypeHost
 import org.gradle.api.tasks.testing.logging.TestExceptionFormat
-import java.util.Locale
 
 plugins {
     `java-library`
@@ -9,11 +12,6 @@ plugins {
 
 repositories {
     mavenCentral()
-}
-
-configure<JavaPluginExtension> {
-    withJavadocJar()
-    withSourcesJar()
 }
 
 configure<SpotlessExtension> {
@@ -33,10 +31,6 @@ java {
 tasks.withType<JavaCompile> {
     options.compilerArgs.add("-Werror")
     options.release.set(8)
-}
-
-tasks.named<Jar>("javadocJar") {
-    setZip64(true)
 }
 
 tasks.jar {

--- a/buildSrc/src/main/kotlin/langsmith.kotlin.gradle.kts
+++ b/buildSrc/src/main/kotlin/langsmith.kotlin.gradle.kts
@@ -1,4 +1,5 @@
 import com.diffplug.gradle.spotless.SpotlessExtension
+import com.vanniktech.maven.publish.*
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {

--- a/buildSrc/src/main/kotlin/langsmith.publish.gradle.kts
+++ b/buildSrc/src/main/kotlin/langsmith.publish.gradle.kts
@@ -1,3 +1,5 @@
+import com.vanniktech.maven.publish.MavenPublishBaseExtension
+import com.vanniktech.maven.publish.SonatypeHost
 import org.gradle.api.publish.PublishingExtension
 import org.gradle.api.publish.maven.MavenPublication
 import org.gradle.kotlin.dsl.configure
@@ -5,63 +7,46 @@ import org.gradle.kotlin.dsl.create
 import org.gradle.kotlin.dsl.get
 
 plugins {
-    `maven-publish`
-    `signing`
+    id("com.vanniktech.maven.publish")
 }
 
-configure<PublishingExtension> {
-    publications {
-        create<MavenPublication>("maven") {
-            from(components["java"])
+repositories {
+    gradlePluginPortal()
+    mavenCentral()
+}
 
-            pom {
-                name.set("LangSmith")
-                description.set("An SDK library for LangSmith")
-                url.set("https://docs.LangSmith.com")
+extra["signingInMemoryKey"] = System.getenv("GPG_SIGNING_KEY")
+extra["signingInMemoryKeyId"] = System.getenv("GPG_SIGNING_KEY_ID")
+extra["signingInMemoryKeyPassword"] = System.getenv("GPG_SIGNING_PASSWORD")
 
-                licenses {
-                    license {
-                        name.set("Apache-2.0")
-                    }
-                }
+configure<MavenPublishBaseExtension> {
+    signAllPublications()
+    publishToMavenCentral(SonatypeHost.CENTRAL_PORTAL)
 
-                developers {
-                    developer {
-                        name.set("Lang Smith")
-                        email.set("dev-feedback@LangSmith.com")
-                    }
-                }
+    this.coordinates(project.group.toString(), project.name, project.version.toString())
 
-                scm {
-                    connection.set("scm:git:git://github.com/langchain-ai/langsmith-java.git")
-                    developerConnection.set("scm:git:git://github.com/langchain-ai/langsmith-java.git")
-                    url.set("https://github.com/langchain-ai/langsmith-java")
-                }
+    pom {
+        name.set("LangSmith")
+        description.set("An SDK library for LangSmith")
+        url.set("https://docs.LangSmith.com")
 
-                versionMapping {
-                    allVariants {
-                        fromResolutionResult()
-                    }
-                }
+        licenses {
+            license {
+                name.set("Apache-2.0")
             }
         }
-    }
-}
 
-signing {
-    val signingKeyId = System.getenv("GPG_SIGNING_KEY_ID")?.ifBlank { null }
-    val signingKey = System.getenv("GPG_SIGNING_KEY")?.ifBlank { null }
-    val signingPassword = System.getenv("GPG_SIGNING_PASSWORD")?.ifBlank { null }
-    if (signingKey != null && signingPassword != null) {
-        useInMemoryPgpKeys(
-            signingKeyId,
-            signingKey,
-            signingPassword,
-        )
-        sign(publishing.publications["maven"])
-    }
-}
+        developers {
+            developer {
+                name.set("Lang Smith")
+                email.set("dev-feedback@LangSmith.com")
+            }
+        }
 
-tasks.publish {
-    dependsOn(":closeAndReleaseSonatypeStagingRepository")
+        scm {
+            connection.set("scm:git:git://github.com/langchain-ai/langsmith-java.git")
+            developerConnection.set("scm:git:git://github.com/langchain-ai/langsmith-java.git")
+            url.set("https://github.com/langchain-ai/langsmith-java")
+        }
+    }
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.0.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.1.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
Replace `io.github.gradle-nexus.publish-plugin` with `com.vanniktech:gradle-maven-publish-plugin:0.28.0` so that releases go to the new Maven Central Portal.