### PR TITLE
chore: Move runner to ubuntu-latest-l to avoid OOMs

### DIFF
--- a/.github/workflows/publish-sonatype.yml
+++ b/.github/workflows/publish-sonatype.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   publish:
     name: publish
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-l
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## Description

- Allow dokka to finish javadoc building.