### PR TITLE
fix: formatting error in record experiment example

### DIFF
--- a/langsmith-java-example/src/main/kotlin/com/langchain/smith/example/RecordExperimentExample.kt
+++ b/langsmith-java-example/src/main/kotlin/com/langchain/smith/example/RecordExperimentExample.kt
@@ -197,9 +197,10 @@ fun main() {
         val example = createdExamples[index]
         val runId = java.util.UUID.randomUUID().toString()
 
-        // Generate dotted_order following LangSmith SDK pattern: YYYYMMDDTHHMMSSffffffZ + UUID
-        // See: https://github.com/langchain-ai/langsmith-sdk/blob/main/python/langsmith/run_trees.py
-        val dottedOrderFormatter = DateTimeFormatter.ofPattern("yyyyMMdd'T'HHmmssSSSSSSSSS'Z'")
+        // Generate dotted_order following LangSmith format: {timestamp}Z{run_id}
+        // Format: YYYYMMDDTHHMMSSmmmmmmZ{run_id} where mmmmmm is 6 digits for microseconds
+        // For root runs: single part (no dots), timestamp matches trace_id (run_id)
+        val dottedOrderFormatter = DateTimeFormatter.ofPattern("yyyyMMdd'T'HHmmssSSSSSS'Z'")
         val dottedOrder = startTime.format(dottedOrderFormatter) + runId
 
         Run.builder()


### PR DESCRIPTION
Seeing this error in record experiment example.

> Exception in thread "main" com.langchain.smith.errors.BadRequestException: 400: {error=Bad request: invalid 'dotted_order': invalid timestamp in dotted_order 20251208T144553541735000 at index 0: parsing time "20251208T144553541735000" as "2006-01-02T15:04:05.999999999Z07:00": cannot parse "1208T144553541735000" as "-" for run_id:ecec66cf-da94-4d27-a29f-08ca642db9d7 trace_id:ecec66cf-da94-4d27-a29f-08ca642db9d7 dotted_order:20251208T144553541735000Zecec66cf-da94-4d27-a29f-08ca642db9d7 parent_run_id:<nil>}

Fixed formatting in timestamp.