### PR TITLE
Fix markdown formatting and grammar in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -274,7 +274,7 @@ ExampleUploadFromCsvParams params = ExampleUploadFromCsvParams.builder()
 List<Example> examples = client.examples().uploadFromCsv(params);
 ```
 
-Note that when passing a non-`Path` its filename is unknown so it will not be included in the request. To manually set a filename, pass a [`MultipartField`](langsmith-java-core/src/main/kotlin/com/langchain/smith/core/Values.kt):
+Note that when passing a non-`Path`, its filename is unknown, so it will not be included in the request. To manually set a filename, pass a [`MultipartField`](langsmith-java-core/src/main/kotlin/com/langchain/smith/core/Values.kt):
 
 ```java
 import com.langchain.smith.core.MultipartField;

--- a/langsmith-java-example/README.md
+++ b/langsmith-java-example/README.md
@@ -87,8 +87,6 @@ Located in `src/main/kotlin/com/langchain/smith/example/`
 
 This example follows the [LangSmith Prompt Management docs](https://docs.langchain.com/langsmith/manage-prompts-programmatically) and uses the SDK directly.
 
-```
-
 **Additional features:**
 - Use prompts with OpenAI to generate responses
 - Update prompt metadata and descriptions


### PR DESCRIPTION
This PR fixes two documentation issues:

1. Removed empty code block in langsmith-java-example/README.md that was causing incorrect formatting
2. Added missing commas in README.md for better readability: "Note that when passing a non-`Path`, its filename is unknown, so it will not be included in the request."