### PR TITLE
fix: patch 27 security alerts (critical + high severity)

### DIFF
--- a/langsmith-java-core/build.gradle.kts
+++ b/langsmith-java-core/build.gradle.kts
@@ -19,14 +19,14 @@ configurations.all {
 }
 
 dependencies {
-    api("com.fasterxml.jackson.core:jackson-core:2.18.2")
-    api("com.fasterxml.jackson.core:jackson-databind:2.18.2")
+    api("com.fasterxml.jackson.core:jackson-core:2.18.6")
+    api("com.fasterxml.jackson.core:jackson-databind:2.18.6")
     api("com.google.errorprone:error_prone_annotations:2.33.0")
 
-    implementation("com.fasterxml.jackson.core:jackson-annotations:2.18.2")
-    implementation("com.fasterxml.jackson.datatype:jackson-datatype-jdk8:2.18.2")
-    implementation("com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.18.2")
-    implementation("com.fasterxml.jackson.module:jackson-module-kotlin:2.18.2")
+    implementation("com.fasterxml.jackson.core:jackson-annotations:2.18.6")
+    implementation("com.fasterxml.jackson.datatype:jackson-datatype-jdk8:2.18.6")
+    implementation("com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.18.6")
+    implementation("com.fasterxml.jackson.module:jackson-module-kotlin:2.18.6")
     implementation("org.apache.httpcomponents.core5:httpcore5:5.2.4")
     implementation("org.apache.httpcomponents.client5:httpclient5:5.3.1")
     
@@ -49,6 +49,24 @@ dependencies {
     // Users who call AnthropicPayload.toAnthropicParams() must add this to their own dependencies.
     compileOnly("com.anthropic:anthropic-java:2.18.0")
     testImplementation("com.anthropic:anthropic-java:2.18.0")
+
+    // Security: constrain vulnerable transitive test dependencies (from wiremock-jre8).
+    // These constraints apply to the test scope only and do not affect published artifacts.
+    constraints {
+        // CVE-2024-13009, CVE-2025-5115, CVE-2024-22201, CVE-2023-36478
+        testImplementation("org.eclipse.jetty:jetty-server") { version { require("9.4.57.v20241219") } }
+        testImplementation("org.eclipse.jetty.http2:http2-common") { version { require("9.4.58") } }
+        testImplementation("org.eclipse.jetty.http2:http2-hpack") { version { require("9.4.58") } }
+        // CVE-2023-6481, CVE-2023-6378
+        testImplementation("ch.qos.logback:logback-core") { version { require("1.2.13") } }
+        testImplementation("ch.qos.logback:logback-classic") { version { require("1.2.13") } }
+        // CVE-2025-48976, CVE-2023-24998
+        testImplementation("commons-fileupload:commons-fileupload") { version { require("1.6.0") } }
+        // CVE-2024-47554
+        testImplementation("commons-io:commons-io") { version { require("2.14.0") } }
+        // CVE-2023-1370
+        testImplementation("net.minidev:json-smart") { version { require("2.4.9") } }
+    }
 
     testImplementation(kotlin("test"))
     // Simple logging for tests only

--- a/langsmith-java-example/build.gradle.kts
+++ b/langsmith-java-example/build.gradle.kts
@@ -26,6 +26,26 @@ dependencies {
     implementation(platform("org.springframework.boot:spring-boot-dependencies:2.7.18"))
     implementation("org.springframework.boot:spring-boot-starter-web")
     implementation("org.springframework.boot:spring-boot-starter")
+
+    // Security: constrain vulnerable transitive dependencies from Spring Boot 2.7.18.
+    // Spring Boot 2.7.x is EOL; these constraints override the managed versions in-place.
+    // None of these affect published artifacts (this is a non-published example module).
+    constraints {
+        // CVE-2025-24813 (CRITICAL), CVE-2026-24734, CVE-2025-55752, CVE-2025-53506,
+        // CVE-2025-52520, CVE-2025-48989, CVE-2025-48988, CVE-2024-56337, CVE-2024-50379, CVE-2024-34750
+        // Remove this constraint when upgrading to Spring Boot 3.x (which manages Tomcat 10+).
+        implementation("org.apache.tomcat.embed:tomcat-embed-core") { version { require("9.0.115") } }
+        implementation("org.apache.tomcat.embed:tomcat-embed-websocket") { version { require("9.0.115") } }
+        // CVE-2024-22243, CVE-2024-22259, CVE-2024-22262
+        // Note: CVE-2016-1000027 (CRITICAL) requires spring-web 6.0.0 — needs Spring Boot 3.x upgrade.
+        implementation("org.springframework:spring-web") { version { require("5.3.34") } }
+        implementation("org.springframework:spring-webmvc") { version { require("5.3.34") } }
+        // CVE-2023-6481, CVE-2023-6378
+        implementation("ch.qos.logback:logback-core") { version { require("1.2.13") } }
+        implementation("ch.qos.logback:logback-classic") { version { require("1.2.13") } }
+        // CVE-2022-25857 (note: CVE-2022-1471 requires snakeyaml 2.0 which is incompatible with Spring Boot 2.7.x)
+        implementation("org.yaml:snakeyaml") { version { require("1.31") } }
+    }
 }
 
 tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile>().configureEach {


### PR DESCRIPTION
## Security Alert Patch

Resolves 27 Dependabot security alerts in the critical + high severity tier.

### Packages Updated

| Package | Old Constraint | New Constraint | Strategy | Scope | CVEs Resolved |
|---------|---------------|----------------|----------|-------|---------------|
| `jackson-core` + `jackson-databind` + `jackson-annotations` + `jackson-datatype-*` + `jackson-module-kotlin` | 2.18.2 | 2.18.6 | A – direct bump | published (api dep) | GHSA-72hv-8253-57qq, CVE-2025-52999 |
| `tomcat-embed-core`, `tomcat-embed-websocket` | SB 2.7.18 BOM (~9.0.82) | ≥ 9.0.115 | C – constraint | dev-only (example) | CVE-2025-24813 (CRITICAL), CVE-2026-24734, CVE-2025-55752, CVE-2025-53506, CVE-2025-52520, CVE-2025-48989, CVE-2025-48988, CVE-2024-56337, CVE-2024-50379, CVE-2024-34750 |
| `spring-web`, `spring-webmvc` | SB 2.7.18 BOM | ≥ 5.3.34 | C – constraint | dev-only (example) | CVE-2024-22243, CVE-2024-22259, CVE-2024-22262 |
| `jetty-server` | wiremock-jre8 transitive | ≥ 9.4.57.v20241219 | C – constraint | dev-only (test) | CVE-2024-13009 |
| `http2-common`, `http2-hpack` | wiremock-jre8 transitive | ≥ 9.4.58 | C – constraint | dev-only (test) | CVE-2025-5115, CVE-2024-22201, CVE-2023-36478 |
| `logback-core`, `logback-classic` | 1.2.x | ≥ 1.2.13 | C – constraint | dev-only (test + example) | CVE-2023-6481, CVE-2023-6378 |
| `commons-fileupload` | < 1.5 | ≥ 1.6.0 | C – constraint | dev-only (test) | CVE-2025-48976, CVE-2023-24998 |
| `commons-io` | < 2.14.0 | ≥ 2.14.0 | C – constraint | dev-only (test) | CVE-2024-47554 |
| `net.minidev:json-smart` | < 2.4.9 | ≥ 2.4.9 | C – constraint | dev-only (test) | CVE-2023-1370 |
| `snakeyaml` | SB 2.7.18 BOM (1.x) | ≥ 1.31 | C – constraint | dev-only (example) | CVE-2022-25857 |

**Strategy legend:**
- A = direct version bump in the manifest declaration
- C = version constraint/override — applies only to the local classpath, valid for dev-only scope

**Scope legend:**
- `published` = ships in the published Maven artifacts (`langsmith-java-core`, etc.)
- `dev-only` = test scope or non-published `langsmith-java-example` module only

### Upstream Issues / Known Limitations

**CVE-2016-1000027 (CRITICAL) — spring-web requires 6.0.0**
Spring 6.x requires Spring Boot 3.x, which is a significant migration from the current 2.7.18 in the example module. This CVE involves `HttpInvokerServiceExporter` which is not used in the example code. Remediation requires a Spring Boot 3.x upgrade tracked separately.

**CVE-2022-1471 (HIGH) — snakeyaml requires 2.0**
Spring Boot 2.7.x uses snakeyaml 1.x internally for application config parsing. Forcing snakeyaml 2.0 in a Spring Boot 2.7.x project is likely to cause runtime failures in YAML config parsing. Remediation requires a Spring Boot 3.x upgrade (which ships snakeyaml 2.0 natively).

**No fix available (first_patched = null):**
- `spring-core` CVE-2025-41249 (HIGH)
- `spring-webmvc` CVE-2024-38819, CVE-2024-38816 (HIGH)
- `spring-boot` CVE-2025-22235 (HIGH)

**Jackson test force resolution (2.14.0)**
`langsmith-java-core` intentionally forces Jackson to 2.14.0 in the test compilation/runtime scope for backward-compatibility testing. The published api dependency now ships 2.18.6 (secure for end users). The test force is left unchanged — raising it would alter the stated compatibility floor.

### CVE Details

| CVE/GHSA | Package | Summary |
|----------|---------|---------|
| GHSA-72hv-8253-57qq | jackson-core | Jackson Core vulnerability (HIGH) |
| CVE-2025-52999 | jackson-core | Jackson Core vulnerability (HIGH) |
| CVE-2025-24813 | tomcat-embed-core | Apache Tomcat Potential RCE with partial PUT (CRITICAL) |
| CVE-2026-24734 | tomcat-embed-core | Apache Tomcat Improper Input Validation (HIGH) |
| CVE-2025-55752, CVE-2025-53506, CVE-2025-52520, CVE-2025-48989, CVE-2025-48988, CVE-2024-56337, CVE-2024-50379, CVE-2024-34750 | tomcat-embed-core | Various Apache Tomcat HIGH severity CVEs |
| CVE-2024-22243, CVE-2024-22259, CVE-2024-22262 | spring-web | Spring Framework URL parsing vulnerabilities (HIGH) |
| CVE-2024-13009 | jetty-server | Eclipse Jetty vulnerability (HIGH) |
| CVE-2025-5115, CVE-2024-22201 | http2-common | Eclipse Jetty HTTP/2 vulnerabilities (HIGH) |
| CVE-2023-36478 | http2-hpack | Eclipse Jetty HTTP/2 HPACK vulnerability (HIGH) |
| CVE-2023-6481, CVE-2023-6378 | logback-core/classic | Logback deserialization vulnerabilities (HIGH) |
| CVE-2025-48976, CVE-2023-24998 | commons-fileupload | Apache Commons FileUpload DoS (HIGH) |
| CVE-2024-47554 | commons-io | Apache Commons IO path traversal (HIGH) |
| CVE-2023-1370 | json-smart | JSON Smart stack overflow (HIGH) |
| CVE-2022-25857 | snakeyaml | SnakeYAML DoS (HIGH) |

### Linear Tickets

No matching Linear tickets found.

### Verification

- [x] All version constraints target minimum safe version (not latest)
- [x] No major-version bumps in published artifact dependencies
- [x] Both files checked — no lockfiles in this Gradle project
- [ ] CI: linters + tests (Gradle build with Java 21)

🤖 Submitted by langster-patch