### PR TITLE
ci: add minimum workflow permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,9 @@ on:
       - 'stl-preview-head/**'
       - 'stl-preview-base/**'
 
+permissions:
+  contents: read
+
 jobs:
   lint:
     timeout-minutes: 15

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -7,6 +7,10 @@ on:
     branches: [main, next]
   schedule:
     - cron: "0 0 * * 0" # Weekly scan on Sunday at midnight
+
+permissions:
+  contents: read
+
 jobs:
   analyze:
     name: Analyze

--- a/.github/workflows/publish-sonatype.yml
+++ b/.github/workflows/publish-sonatype.yml
@@ -8,6 +8,9 @@ on:
   release:
     types: [published]
 
+permissions:
+  contents: read
+
 jobs:
   publish:
     name: publish

--- a/.github/workflows/release-doctor.yml
+++ b/.github/workflows/release-doctor.yml
@@ -1,9 +1,12 @@
 name: Release Doctor
 on:
-  pull_request:
+  pull_request_target:
     branches:
       - main
   workflow_dispatch:
+
+permissions:
+  contents: read
 
 jobs:
   release_doctor:


### PR DESCRIPTION
## Summary

- Add top-level `permissions: contents: read` to all 4 workflow files (`ci.yml`, `codeql.yml`, `publish-sonatype.yml`, `release-doctor.yml`) — without explicit permissions, `GITHUB_TOKEN` inherits broad org/repo defaults
- Change `release-doctor.yml` trigger from `pull_request` to `pull_request_target` — the workflow uses Sonatype/GPG secrets, and `pull_request` runs the workflow definition from the PR branch, allowing a PR author to modify the workflow to exfiltrate those secrets

## Test plan

- [x] CI passes on this PR
- [x] Release Doctor workflow still triggers correctly on `release-please` and `next` branch PRs
- [x] Verify no jobs break due to missing permissions (each write-needing job already declares its own job-level permissions)
