### PR TITLE
ci: SHA-pin third-party Gradle actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
           cache: gradle
 
       - name: Set up Gradle
-        uses: gradle/actions/setup-gradle@v6
+        uses: gradle/actions/setup-gradle@205054a7257716ec64af10a2e2ff1ac5d3b132db # v6
 
       - name: Run lints
         run: ./scripts/lint
@@ -61,7 +61,7 @@ jobs:
           cache: gradle
 
       - name: Set up Gradle
-        uses: gradle/actions/setup-gradle@v6
+        uses: gradle/actions/setup-gradle@205054a7257716ec64af10a2e2ff1ac5d3b132db # v6
 
       - name: Build SDK
         run: ./scripts/build
@@ -103,7 +103,7 @@ jobs:
           cache: gradle
 
       - name: Set up Gradle
-        uses: gradle/gradle-build-action@v3
+        uses: gradle/gradle-build-action@12318b01111bfa6462c00534ffa998f8b397b979 # v3
 
       - name: Run tests
         run: ./scripts/test

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -28,7 +28,7 @@ jobs:
             8
             21
       - name: Set up Gradle
-        uses: gradle/actions/setup-gradle@v6
+        uses: gradle/actions/setup-gradle@205054a7257716ec64af10a2e2ff1ac5d3b132db # v6
 
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v4

--- a/.github/workflows/publish-sonatype.yml
+++ b/.github/workflows/publish-sonatype.yml
@@ -26,7 +26,7 @@ jobs:
           cache: gradle
 
       - name: Set up Gradle
-        uses: gradle/gradle-build-action@v3
+        uses: gradle/gradle-build-action@12318b01111bfa6462c00534ffa998f8b397b979 # v3
 
       - name: Publish to Sonatype
         run: |-


### PR DESCRIPTION
## Summary

Pin third-party Gradle actions to full commit SHAs to prevent supply chain attacks via tag hijacking. Mutable tags (`@v6`, `@v3`) can be force-pushed by the action maintainer or a compromised account.

- `gradle/actions/setup-gradle@v6` → `@205054a7257716ec64af10a2e2ff1ac5d3b132db` (ci.yml ×2, codeql.yml)
- `gradle/gradle-build-action@v3` → `@12318b01111bfa6462c00534ffa998f8b397b979` (ci.yml, publish-sonatype.yml)

## Test plan

- [x] CI passes on this PR
- [x] Gradle build and setup steps execute successfully with pinned SHAs