### PR TITLE
feat: Adds support for tracing streams with traceable

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -211,7 +211,7 @@ Tests skip gracefully via `assumeTrue` if keys are missing.
 ## Code style
 
 - `toString()` should be single-line, following the `ClassName{field=value, field=value}` convention used by the rest of the SDK.
-- Avoid `@Suppress("UNCHECKED_CAST")` — restructure code to use safe patterns (`as? String`, `is Map<*, *>` with `entries.associate`, etc).
+- Avoid `@Suppress("UNCHECKED_CAST")` — restructure code to use safe patterns (`as? String`, `is Map<*, *>` with `entries.associate`, etc). The only acceptable use is JDK dynamic proxies (`Proxy.newProxyInstance` returns `Object`), which must include a comment explaining why the cast is safe.
 - Use named arguments for constructor/function calls with 2+ parameters, especially when types could be confused:
   ```kotlin
   // Good

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -91,6 +91,25 @@ override fun toString(): String =
         "}"
 ```
 
+### Prefer extension functions over type casts
+
+When adding behavior to a type you don't own, use a `private` extension function instead of casting to an implementation type:
+
+```kotlin
+// Good — extension function, no cast needed
+private fun Stream<*>.withErrorTracking(
+    errorRef: AtomicReference<Throwable>,
+    exhaustedRef: AtomicBoolean,
+): Stream<Any?> { ... }
+
+val instrumented = result.withErrorTracking(iterationError, streamExhausted)
+
+// Bad — casting to implementation type
+val instrumented = wrapStreamWithErrorCapture(result, iterationError, streamExhausted)
+// or worse:
+(runs as? RunServiceImpl)?.flush()
+```
+
 ### Use `partition` instead of double `filter`
 
 ```kotlin
@@ -224,6 +243,7 @@ Tests skip gracefully via `assumeTrue` if keys are missing.
   // Bad — positional args are ambiguous
   PromptMessage(PromptMessage.Role.HUMAN, template, templateFormat = templateFormat)
   ```
+- Name functions from the caller's perspective — describe what the caller gets, not what the function does internally. Prefer `stream.withErrorTracking()` over `wrapStreamWithErrorCapture(stream)`.
 - When an `Optional` has a fallback default, use `orElse(default)` directly instead of `orElse(null) ?: default`:
   ```kotlin
   // Good — default goes straight into orElse

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -211,7 +211,7 @@ Tests skip gracefully via `assumeTrue` if keys are missing.
 ## Code style
 
 - `toString()` should be single-line, following the `ClassName{field=value, field=value}` convention used by the rest of the SDK.
-- Avoid `@Suppress("UNCHECKED_CAST")` — restructure code to use safe patterns (`as? String`, `is Map<*, *>` with `entries.associate`, etc). The only acceptable use is JDK dynamic proxies (`Proxy.newProxyInstance` returns `Object`), which must include a comment explaining why the cast is safe.
+- Avoid `@Suppress("UNCHECKED_CAST")` — restructure code to use safe patterns (`as? String`, `is Map<*, *>` with `entries.associate`, etc). When unavoidable (e.g. generic type erasure after an `is` check), add a comment explaining why the cast is safe.
 - Use named arguments for constructor/function calls with 2+ parameters, especially when types could be confused:
   ```kotlin
   // Good

--- a/langsmith-java-core/src/main/kotlin/com/langchain/smith/tracing/TraceProcessIO.kt
+++ b/langsmith-java-core/src/main/kotlin/com/langchain/smith/tracing/TraceProcessIO.kt
@@ -47,11 +47,29 @@ import java.util.function.Function
 class TraceProcessIO<PI, PO>(
     processInputs: Function<PI, Map<String, Any?>>? = null,
     processOutputs: Function<PO, Map<String, Any?>>? = null,
+    aggregator: Function<List<Any?>, Any?>? = null,
 ) {
     // Store erased wrappers so traceable overloads can call these without casts.
     // erase() converts Function<T, R> to Function<Any?, R> — safe because T erases to Object.
     internal val inputsFn: Function<Any?, Map<String, Any?>>? = processInputs?.erase()
     internal val outputsFn: Function<Any?, Map<String, Any?>>? = processOutputs?.erase()
+
+    /**
+     * Optional aggregator for streaming results.
+     *
+     * When the traced function returns an [AutoCloseable] with a `stream()` method (e.g. OpenAI's
+     * `StreamResponse`), `traceable` will:
+     * 1. Return the stream to the caller immediately (so they can iterate)
+     * 2. Collect each element as the caller iterates via `stream()`
+     * 3. Call this aggregator with the collected chunks when `close()` is called
+     * 4. Pass the aggregated result through [processOutputs] and record it as run output
+     *
+     * If no aggregator is set but the result is stream-like, the raw list of chunks is recorded.
+     *
+     * **Important:** Callers must close the stream (via `use {}` in Kotlin or try-with-resources in
+     * Java) to ensure the traced run is finalized. Abandoned streams will leave runs open.
+     */
+    internal val aggregatorFn: Function<List<Any?>, Any?>? = aggregator
 
     companion object {
         /** Creates a new [Builder]. */
@@ -82,6 +100,7 @@ class TraceProcessIO<PI, PO>(
     class Builder<PI, PO> internal constructor() {
         private var processInputs: Function<PI, Map<String, Any?>>? = null
         private var processOutputs: Function<PO, Map<String, Any?>>? = null
+        private var aggregator: Function<List<Any?>, Any?>? = null
 
         /** Callback to transform the input before it is recorded on the run. */
         fun processInputs(processInputs: Function<PI, Map<String, Any?>>) = apply {
@@ -93,9 +112,23 @@ class TraceProcessIO<PI, PO>(
             this.processOutputs = processOutputs
         }
 
+        /**
+         * Aggregator for streaming results. Reduces collected chunks into a single output that is
+         * then passed through [processOutputs].
+         */
+        fun aggregator(aggregator: Function<List<Any?>, Any?>) = apply {
+            this.aggregator = aggregator
+        }
+
         /** Builds the [TraceProcessIO]. */
-        fun build() = TraceProcessIO(processInputs = processInputs, processOutputs = processOutputs)
+        fun build() =
+            TraceProcessIO(
+                processInputs = processInputs,
+                processOutputs = processOutputs,
+                aggregator = aggregator,
+            )
     }
 
-    override fun toString(): String = "TraceProcessIO{inputs=$inputsFn, outputs=$outputsFn}"
+    override fun toString(): String =
+        "TraceProcessIO{inputs=$inputsFn, outputs=$outputsFn, aggregator=$aggregatorFn}"
 }

--- a/langsmith-java-core/src/main/kotlin/com/langchain/smith/tracing/TraceProcessIO.kt
+++ b/langsmith-java-core/src/main/kotlin/com/langchain/smith/tracing/TraceProcessIO.kt
@@ -13,10 +13,13 @@ import java.util.function.Function
  *     - **0-arg** ([traceSupplier]): `Map<String, Any?>` (empty map)
  *     - **2-arg** ([traceBiFunction]): `Pair<I1, I2>`
  *     - **3-arg** ([traceTriFunction]): `Triple<I1, I2, I3>`
- * - [PO] — the type passed to `processOutputs`. This is always the raw output type of the traced
- *   function.
+ * - [PO] — the type passed to `processOutputs`. For non-streaming functions, this is the raw return
+ *   type. For streaming functions (when [aggregator] is set), this is the **aggregated output
+ *   type** — not the stream type. When no aggregator is set but the return is stream-like,
+ *   `processOutputs` receives a `List<Any?>` of collected chunks.
  *
- * When [inputs] is set, it replaces the default input serialization entirely. Same for [outputs].
+ * When `processInputs` is set, it replaces the default input serialization entirely. Same for
+ * `processOutputs`.
  *
  * ## Example (Kotlin)
  *
@@ -57,17 +60,21 @@ class TraceProcessIO<PI, PO>(
     /**
      * Optional aggregator for streaming results.
      *
-     * When the traced function returns an [AutoCloseable] with a `stream()` method (e.g. OpenAI's
-     * `StreamResponse`), `traceable` will:
-     * 1. Return the stream to the caller immediately (so they can iterate)
+     * When the traced function returns an interface-based [AutoCloseable] whose `stream()` method
+     * returns [java.util.stream.Stream] (e.g. OpenAI's `StreamResponse`), `traceable` will:
+     * 1. Return a proxy that implements the same interfaces as the original return value
      * 2. Collect each element as the caller iterates via `stream()`
-     * 3. Call this aggregator with the collected chunks when `close()` is called
+     * 3. Call this aggregator with the collected chunks when the **outer object** is closed
      * 4. Pass the aggregated result through [processOutputs] and record it as run output
      *
      * If no aggregator is set but the result is stream-like, the raw list of chunks is recorded.
      *
-     * **Important:** Callers must close the stream (via `use {}` in Kotlin or try-with-resources in
-     * Java) to ensure the traced run is finalized. Abandoned streams will leave runs open.
+     * **Lifecycle:** Callers must close the outer stream object (via `use {}` in Kotlin or
+     * try-with-resources in Java) to finalize the traced run. Closing just the `Stream<T>` from
+     * `stream()` is not sufficient. Abandoned stream objects will leave runs open indefinitely.
+     *
+     * **Limitations:** Stream wrapping only works for return types that implement interfaces
+     * (required by JDK dynamic proxies). Concrete classes without interfaces are not supported.
      */
     internal val aggregatorFn: Function<List<Any?>, Any?>? = aggregator
 

--- a/langsmith-java-core/src/main/kotlin/com/langchain/smith/tracing/TraceProcessIO.kt
+++ b/langsmith-java-core/src/main/kotlin/com/langchain/smith/tracing/TraceProcessIO.kt
@@ -15,8 +15,7 @@ import java.util.function.Function
  *     - **3-arg** ([traceTriFunction]): `Triple<I1, I2, I3>`
  * - [PO] — the type passed to `processOutputs`. For non-streaming functions, this is the raw return
  *   type. For streaming functions (when [aggregator] is set), this is the **aggregated output
- *   type** — not the stream type. When no aggregator is set but the return is stream-like,
- *   `processOutputs` receives a `List<Any?>` of collected chunks.
+ *   type** returned by the aggregator — not the stream type itself.
  *
  * When `processInputs` is set, it replaces the default input serialization entirely. Same for
  * `processOutputs`.
@@ -58,16 +57,17 @@ class TraceProcessIO<PI, PO>(
     internal val outputsFn: Function<Any?, Map<String, Any?>>? = processOutputs?.erase()
 
     /**
-     * Optional aggregator for streaming results.
+     * Aggregator for streaming results. Setting this opts into stream tracing.
      *
-     * When the traced function returns an interface-based [AutoCloseable] whose `stream()` method
-     * returns [java.util.stream.Stream] (e.g. OpenAI's `StreamResponse`), `traceable` will:
+     * When set and the traced function returns an interface-based [AutoCloseable] whose `stream()`
+     * method returns [java.util.stream.Stream] (e.g. OpenAI's `StreamResponse`), `traceable` will:
      * 1. Return a proxy that implements the same interfaces as the original return value
      * 2. Collect each element as the caller iterates via `stream()`
      * 3. Call this aggregator with the collected chunks when the **outer object** is closed
      * 4. Pass the aggregated result through [processOutputs] and record it as run output
      *
-     * If no aggregator is set but the result is stream-like, the raw list of chunks is recorded.
+     * Without an aggregator, stream-like return values are treated normally — the run is completed
+     * immediately on return, same as any other value.
      *
      * **Lifecycle:** Callers must close the outer stream object (via `use {}` in Kotlin or
      * try-with-resources in Java) to finalize the traced run. Closing just the `Stream<T>` from

--- a/langsmith-java-core/src/main/kotlin/com/langchain/smith/tracing/TraceProcessIO.kt
+++ b/langsmith-java-core/src/main/kotlin/com/langchain/smith/tracing/TraceProcessIO.kt
@@ -59,22 +59,19 @@ class TraceProcessIO<PI, PO>(
     /**
      * Aggregator for streaming results. Setting this opts into stream tracing.
      *
-     * When set and the traced function returns an interface-based [AutoCloseable] whose `stream()`
-     * method returns [java.util.stream.Stream] (e.g. OpenAI's `StreamResponse`), `traceable` will:
-     * 1. Return a proxy that implements the same interfaces as the original return value
-     * 2. Collect each element as the caller iterates via `stream()`
-     * 3. Call this aggregator with the collected chunks when the **outer object** is closed
-     * 4. Pass the aggregated result through [processOutputs] and record it as run output
+     * When set and the traced function returns a [java.util.stream.Stream], `traceable` will:
+     * 1. Tee the stream via `peek()` to collect elements as the caller iterates
+     * 2. Register an `onClose()` handler that calls this aggregator with the collected chunks
+     * 3. Pass the aggregated result through [processOutputs] and record it as run output
      *
-     * Without an aggregator, stream-like return values are treated normally — the run is completed
+     * The caller gets back a real [java.util.stream.Stream] — no proxy, no type changes.
+     *
+     * Without an aggregator, `Stream` return values are treated normally — the run is completed
      * immediately on return, same as any other value.
      *
-     * **Lifecycle:** Callers must close the outer stream object (via `use {}` in Kotlin or
-     * try-with-resources in Java) to finalize the traced run. Closing just the `Stream<T>` from
-     * `stream()` is not sufficient. Abandoned stream objects will leave runs open indefinitely.
-     *
-     * **Limitations:** Stream wrapping only works for return types that implement interfaces
-     * (required by JDK dynamic proxies). Concrete classes without interfaces are not supported.
+     * **Lifecycle:** The run is finalized when the stream's `onClose` handler runs. Callers must
+     * close the stream (via `use {}` in Kotlin or try-with-resources in Java) to ensure the run is
+     * completed. Abandoned streams will leave runs open.
      */
     internal val aggregatorFn: Function<List<Any?>, Any?>? = aggregator
 

--- a/langsmith-java-core/src/main/kotlin/com/langchain/smith/tracing/Traceable.kt
+++ b/langsmith-java-core/src/main/kotlin/com/langchain/smith/tracing/Traceable.kt
@@ -693,20 +693,33 @@ private fun <T> executeTraced(config: TraceConfig, inputs: Map<String, Any?>?, b
             if (aggregator != null && result is java.util.stream.Stream<*>) {
                 val chunks = mutableListOf<Any?>()
                 val iterationError = java.util.concurrent.atomic.AtomicReference<Throwable>(null)
+                val streamExhausted = java.util.concurrent.atomic.AtomicBoolean(false)
                 val instrumented =
-                    wrapStreamWithErrorCapture(result, iterationError)
+                    wrapStreamWithErrorCapture(result, iterationError, streamExhausted)
                         .peek { chunks.add(it) }
                         .onClose {
                             try {
+                                // Always try to aggregate whatever chunks we have
+                                var aggregationError: Throwable? = null
+                                if (chunks.isNotEmpty()) {
+                                    try {
+                                        val output = aggregator.apply(chunks)
+                                        run.outputs =
+                                            applyProcessOutputs(config, output)
+                                                ?: toOutputMap(output)
+                                    } catch (e: Throwable) {
+                                        aggregationError = e
+                                    }
+                                }
+
                                 val error = iterationError.get()
+                                run.endTime = nowIso()
                                 if (error != null) {
-                                    run.endTime = nowIso()
                                     run.error = error.stackTraceToString()
-                                } else {
-                                    val output = aggregator.apply(chunks)
-                                    run.endTime = nowIso()
-                                    run.outputs =
-                                        applyProcessOutputs(config, output) ?: toOutputMap(output)
+                                } else if (!streamExhausted.get()) {
+                                    run.error = "Stream cancelled"
+                                } else if (aggregationError != null) {
+                                    run.error = aggregationError.stackTraceToString()
                                 }
                                 run.patchRun()
                             } catch (e: Throwable) {
@@ -741,13 +754,14 @@ private fun <T> executeTraced(config: TraceConfig, inputs: Map<String, Any?>?, b
 private fun wrapStreamWithErrorCapture(
     source: java.util.stream.Stream<*>,
     errorRef: java.util.concurrent.atomic.AtomicReference<Throwable>,
+    exhaustedRef: java.util.concurrent.atomic.AtomicBoolean,
 ): java.util.stream.Stream<Any?> {
     val delegate = source.spliterator()
     val capturing =
         object : java.util.Spliterator<Any?> {
             override fun tryAdvance(action: java.util.function.Consumer<in Any?>): Boolean =
                 try {
-                    delegate.tryAdvance(action)
+                    delegate.tryAdvance(action).also { if (!it) exhaustedRef.set(true) }
                 } catch (e: Throwable) {
                     errorRef.compareAndSet(null, e)
                     throw e

--- a/langsmith-java-core/src/main/kotlin/com/langchain/smith/tracing/Traceable.kt
+++ b/langsmith-java-core/src/main/kotlin/com/langchain/smith/tracing/Traceable.kt
@@ -687,33 +687,37 @@ private fun <T> executeTraced(config: TraceConfig, inputs: Map<String, Any?>?, b
         try {
             val result = block()
 
-            // Only wrap stream-like results when the caller explicitly opted in by setting
-            // an aggregator on TraceProcessIO. Without an aggregator, the return value is
-            // treated normally (recorded immediately, run completed on return).
-            val streamMethod =
-                if (config.processTracedIO?.aggregatorFn != null && result is AutoCloseable) {
-                    try {
-                        result::class.java.getMethod("stream").takeIf {
-                            java.util.stream.Stream::class.java.isAssignableFrom(it.returnType)
+            // If the result is a java.util.stream.Stream and an aggregator is configured,
+            // instrument it: collect chunks via peek(), finalize the run via onClose().
+            val aggregator = config.processTracedIO?.aggregatorFn
+            if (aggregator != null && result is java.util.stream.Stream<*>) {
+                val chunks = mutableListOf<Any?>()
+                val iterationError = java.util.concurrent.atomic.AtomicReference<Throwable>(null)
+                val instrumented =
+                    wrapStreamWithErrorCapture(result, iterationError)
+                        .peek { chunks.add(it) }
+                        .onClose {
+                            try {
+                                val error = iterationError.get()
+                                if (error != null) {
+                                    run.endTime = nowIso()
+                                    run.error = error.stackTraceToString()
+                                } else {
+                                    val output = aggregator.apply(chunks)
+                                    run.endTime = nowIso()
+                                    run.outputs =
+                                        applyProcessOutputs(config, output) ?: toOutputMap(output)
+                                }
+                                run.patchRun()
+                            } catch (e: Throwable) {
+                                run.endTime = nowIso()
+                                run.error = e.stackTraceToString()
+                                run.patchRun()
+                            }
                         }
-                    } catch (_: NoSuchMethodException) {
-                        null
-                    }
-                } else {
-                    null
-                }
-            if (streamMethod != null && result is AutoCloseable) {
-                // The proxy implements the same interfaces as `result`, so this is safe.
-                // We can't prove it statically because the proxy is created via reflection.
-                val proxy =
-                    createTracedStreamProxy(
-                        delegate = result,
-                        run = run,
-                        config = config,
-                        streamMethod = streamMethod,
-                    )
+                // Safe: T is Stream<something>, instrumented is Stream<Any?> — same erasure.
                 @Suppress("UNCHECKED_CAST")
-                return@runWith proxy as T
+                return@runWith instrumented as T
             }
 
             run.endTime = nowIso()
@@ -730,116 +734,20 @@ private fun <T> executeTraced(config: TraceConfig, inputs: Map<String, Any?>?, b
 }
 
 /**
- * Creates a JDK dynamic proxy that implements the same interfaces as [delegate] (e.g.
- * `StreamResponse`), intercepting `stream()` to collect elements and `close()` to record the output
- * on the traced run.
- *
- * Only works for interface-based return types (required by [java.lang.reflect.Proxy]).
- *
- * On `close()`:
- * 1. The delegate is closed first — if cleanup fails, the error is recorded on the run and
- *    rethrown.
- * 2. If an iteration error was captured (via [errorCapturingStream]), it is recorded on the run.
- * 3. Otherwise, the aggregator (if set) is called and the result is recorded via `processOutputs`.
- *    If no aggregator is set, the raw chunk list is recorded.
- *
- * On `stream()`:
- * - Delegates to the underlying `stream()` each call (fresh stream per call).
- * - Chunks are collected via `peek()` and reset on each `stream()` call to avoid double-counting.
- * - The returned stream wraps a [errorCapturingStream] spliterator that captures iteration errors.
+ * Wraps a [java.util.stream.Stream] so that exceptions during iteration are captured into
+ * [errorRef] before being rethrown. This lets the `onClose` handler record the real error instead
+ * of attempting aggregation on partial data.
  */
-private fun createTracedStreamProxy(
-    delegate: AutoCloseable,
-    run: RunTree,
-    config: TraceConfig,
-    streamMethod: java.lang.reflect.Method,
-): Any {
-    val chunks = mutableListOf<Any?>()
-    val closed = java.util.concurrent.atomic.AtomicBoolean(false)
-    val iterationError = java.util.concurrent.atomic.AtomicReference<Throwable>(null)
-
-    val interfaces = delegate::class.java.interfaces
-
-    return java.lang.reflect.Proxy.newProxyInstance(delegate::class.java.classLoader, interfaces) {
-        _,
-        method,
-        args ->
-        when {
-            method.name == "stream" && method.parameterCount == 0 -> {
-                // Clear chunks so repeated stream() calls don't double-count.
-                chunks.clear()
-                iterationError.set(null)
-                // Delegate to the underlying stream() each call (preserves fresh-stream semantics).
-                val raw = invokeUnwrapping(streamMethod, delegate) as java.util.stream.Stream<*>
-                errorCapturingStream(raw.peek { chunks.add(it) }, iterationError)
-            }
-            method.name == "close" && method.parameterCount == 0 -> {
-                if (closed.compareAndSet(false, true)) {
-                    // Close the delegate first — if cleanup fails, record that as the error.
-                    var closeError: Throwable? = null
-                    try {
-                        delegate.close()
-                    } catch (e: Throwable) {
-                        closeError = e
-                    }
-
-                    try {
-                        val error = iterationError.get() ?: closeError
-                        if (error != null) {
-                            run.endTime = nowIso()
-                            run.error = error.stackTraceToString()
-                        } else {
-                            val aggregator = config.processTracedIO!!.aggregatorFn!!
-                            val output = aggregator.apply(chunks)
-                            run.endTime = nowIso()
-                            run.outputs = applyProcessOutputs(config, output) ?: toOutputMap(output)
-                        }
-                        run.patchRun()
-                    } catch (e: Throwable) {
-                        run.endTime = nowIso()
-                        run.error = e.stackTraceToString()
-                        run.patchRun()
-                    }
-
-                    // Rethrow close error so caller sees the failure
-                    if (closeError != null) throw closeError
-                }
-            }
-            else -> {
-                // Unwrap InvocationTargetException so callers see the original exception
-                invokeUnwrapping(method, delegate, args)
-            }
-        }
-    }
-}
-
-/** Invokes a method via reflection, unwrapping [java.lang.reflect.InvocationTargetException]. */
-private fun invokeUnwrapping(
-    method: java.lang.reflect.Method,
-    target: Any,
-    args: Array<out Any?>? = null,
-): Any? =
-    try {
-        if (args != null) method.invoke(target, *args) else method.invoke(target)
-    } catch (e: java.lang.reflect.InvocationTargetException) {
-        throw e.cause ?: e
-    }
-
-/**
- * Wraps a [java.util.stream.Stream] so that exceptions thrown during iteration (e.g. inside
- * `forEach`, `collect`) are captured into [errorRef] before being rethrown. This allows `close()`
- * to record the error on the traced run even if the caller doesn't explicitly catch it.
- */
-private fun errorCapturingStream(
+private fun wrapStreamWithErrorCapture(
     source: java.util.stream.Stream<*>,
     errorRef: java.util.concurrent.atomic.AtomicReference<Throwable>,
-): java.util.stream.Stream<*> {
-    val sourceSpliterator = source.spliterator()
-    val wrapping =
+): java.util.stream.Stream<Any?> {
+    val delegate = source.spliterator()
+    val capturing =
         object : java.util.Spliterator<Any?> {
             override fun tryAdvance(action: java.util.function.Consumer<in Any?>): Boolean =
                 try {
-                    sourceSpliterator.tryAdvance(action)
+                    delegate.tryAdvance(action)
                 } catch (e: Throwable) {
                     errorRef.compareAndSet(null, e)
                     throw e
@@ -847,9 +755,9 @@ private fun errorCapturingStream(
 
             override fun trySplit(): java.util.Spliterator<Any?>? = null
 
-            override fun estimateSize(): Long = sourceSpliterator.estimateSize()
+            override fun estimateSize(): Long = delegate.estimateSize()
 
-            override fun characteristics(): Int = sourceSpliterator.characteristics()
+            override fun characteristics(): Int = delegate.characteristics()
         }
-    return java.util.stream.StreamSupport.stream(wrapping, false).onClose { source.close() }
+    return java.util.stream.StreamSupport.stream(capturing, false).onClose { source.close() }
 }

--- a/langsmith-java-core/src/main/kotlin/com/langchain/smith/tracing/Traceable.kt
+++ b/langsmith-java-core/src/main/kotlin/com/langchain/smith/tracing/Traceable.kt
@@ -686,6 +686,38 @@ private fun <T> executeTraced(config: TraceConfig, inputs: Map<String, Any?>?, b
     return CURRENT_RUN.runWith(run) {
         try {
             val result = block()
+
+            // If the result has a stream() method returning java.util.stream.Stream and is
+            // AutoCloseable, wrap it to defer run completion until the stream is consumed
+            // and closed. This matches OpenAI's StreamResponse and similar patterns.
+            // If an aggregator is configured, the aggregated result is recorded as output;
+            // otherwise the raw list of chunks is recorded.
+            val streamMethod =
+                if (result is AutoCloseable) {
+                    try {
+                        result::class.java.getMethod("stream").takeIf {
+                            java.util.stream.Stream::class.java.isAssignableFrom(it.returnType)
+                        }
+                    } catch (_: NoSuchMethodException) {
+                        null
+                    }
+                } else {
+                    null
+                }
+            if (streamMethod != null && result is AutoCloseable) {
+                // The proxy implements the same interfaces as `result`, so this is safe.
+                // We can't prove it statically because the proxy is created via reflection.
+                val proxy =
+                    createTracedStreamProxy(
+                        delegate = result,
+                        run = run,
+                        config = config,
+                        streamMethod = streamMethod,
+                    )
+                @Suppress("UNCHECKED_CAST")
+                return@runWith proxy as T
+            }
+
             run.endTime = nowIso()
             run.outputs = applyProcessOutputs(config, result) ?: toOutputMap(result)
             run.patchRun()
@@ -697,4 +729,99 @@ private fun <T> executeTraced(config: TraceConfig, inputs: Map<String, Any?>?, b
             throw e
         }
     }
+}
+
+/**
+ * Creates a JDK dynamic proxy that implements the same interfaces as [delegate] (e.g.
+ * `StreamResponse`), intercepting `stream()` to collect elements and `close()` to record the output
+ * on the traced run. If [TraceProcessIO.aggregatorFn] is set, the aggregated result is recorded;
+ * otherwise the raw list of chunks is recorded.
+ *
+ * **Lifecycle:** The run is finalized when `close()` is called. Callers must use `use {}` (Kotlin)
+ * or try-with-resources (Java) to ensure the run is always completed. If an exception occurs during
+ * stream iteration, it is captured as the run error on `close()`.
+ */
+private fun createTracedStreamProxy(
+    delegate: AutoCloseable,
+    run: RunTree,
+    config: TraceConfig,
+    streamMethod: java.lang.reflect.Method,
+): Any {
+    val chunks = mutableListOf<Any?>()
+    val closed = java.util.concurrent.atomic.AtomicBoolean(false)
+    val iterationError = java.util.concurrent.atomic.AtomicReference<Throwable>(null)
+
+    val interfaces = delegate::class.java.interfaces
+
+    return java.lang.reflect.Proxy.newProxyInstance(delegate::class.java.classLoader, interfaces) {
+        _,
+        method,
+        args ->
+        when (method.name) {
+            "stream" -> {
+                // Delegate to the underlying stream() each call (preserves fresh-stream semantics).
+                // Wrap with peek() to collect chunks. Use a wrapping Spliterator to catch errors
+                // during iteration so close() can record them on the run.
+                val raw = streamMethod.invoke(delegate) as java.util.stream.Stream<*>
+                errorCapturingStream(raw.peek { chunks.add(it) }, iterationError)
+            }
+            "close" -> {
+                if (closed.compareAndSet(false, true)) {
+                    try {
+                        val error = iterationError.get()
+                        if (error != null) {
+                            run.endTime = nowIso()
+                            run.error = error.stackTraceToString()
+                            run.patchRun()
+                        } else {
+                            val aggregator = config.processTracedIO?.aggregatorFn
+                            val output =
+                                if (aggregator != null) aggregator.apply(chunks)
+                                else chunks.toList()
+                            run.endTime = nowIso()
+                            run.outputs =
+                                applyProcessOutputs(config, output) ?: toOutputMap(output)
+                            run.patchRun()
+                        }
+                    } catch (e: Throwable) {
+                        run.endTime = nowIso()
+                        run.error = e.stackTraceToString()
+                        run.patchRun()
+                    } finally {
+                        delegate.close()
+                    }
+                }
+            }
+            else -> {
+                if (args != null) method.invoke(delegate, *args) else method.invoke(delegate)
+            }
+        }
+    }
+}
+
+/**
+ * Wraps a [java.util.stream.Stream] so that exceptions thrown during iteration (e.g. inside
+ * `forEach`, `collect`) are captured into [errorRef] before being rethrown. This allows `close()`
+ * to record the error on the traced run even if the caller doesn't explicitly catch it.
+ */
+private fun errorCapturingStream(
+    source: java.util.stream.Stream<*>,
+    errorRef: java.util.concurrent.atomic.AtomicReference<Throwable>,
+): java.util.stream.Stream<*> {
+    val sourceSpliterator = source.spliterator()
+    val wrapping =
+        object : java.util.Spliterator<Any?> {
+            override fun tryAdvance(action: java.util.function.Consumer<in Any?>): Boolean =
+                try {
+                    sourceSpliterator.tryAdvance(action)
+                } catch (e: Throwable) {
+                    errorRef.compareAndSet(null, e)
+                    throw e
+                }
+
+            override fun trySplit(): java.util.Spliterator<Any?>? = null
+            override fun estimateSize(): Long = sourceSpliterator.estimateSize()
+            override fun characteristics(): Int = sourceSpliterator.characteristics()
+        }
+    return java.util.stream.StreamSupport.stream(wrapping, false).onClose { source.close() }
 }

--- a/langsmith-java-core/src/main/kotlin/com/langchain/smith/tracing/Traceable.kt
+++ b/langsmith-java-core/src/main/kotlin/com/langchain/smith/tracing/Traceable.kt
@@ -687,11 +687,9 @@ private fun <T> executeTraced(config: TraceConfig, inputs: Map<String, Any?>?, b
         try {
             val result = block()
 
-            // If the result has a stream() method returning java.util.stream.Stream and is
-            // AutoCloseable, wrap it to defer run completion until the stream is consumed
-            // and closed. This matches OpenAI's StreamResponse and similar patterns.
-            // If an aggregator is configured, the aggregated result is recorded as output;
-            // otherwise the raw list of chunks is recorded.
+            // If the result is an interface-based AutoCloseable with a stream() method
+            // returning java.util.stream.Stream, wrap it in a proxy that defers run
+            // completion until close(). See TraceProcessIO.aggregatorFn for details.
             val streamMethod =
                 if (result is AutoCloseable) {
                     try {
@@ -734,12 +732,21 @@ private fun <T> executeTraced(config: TraceConfig, inputs: Map<String, Any?>?, b
 /**
  * Creates a JDK dynamic proxy that implements the same interfaces as [delegate] (e.g.
  * `StreamResponse`), intercepting `stream()` to collect elements and `close()` to record the output
- * on the traced run. If [TraceProcessIO.aggregatorFn] is set, the aggregated result is recorded;
- * otherwise the raw list of chunks is recorded.
+ * on the traced run.
  *
- * **Lifecycle:** The run is finalized when `close()` is called. Callers must use `use {}` (Kotlin)
- * or try-with-resources (Java) to ensure the run is always completed. If an exception occurs during
- * stream iteration, it is captured as the run error on `close()`.
+ * Only works for interface-based return types (required by [java.lang.reflect.Proxy]).
+ *
+ * On `close()`:
+ * 1. The delegate is closed first — if cleanup fails, the error is recorded on the run and
+ *    rethrown.
+ * 2. If an iteration error was captured (via [errorCapturingStream]), it is recorded on the run.
+ * 3. Otherwise, the aggregator (if set) is called and the result is recorded via `processOutputs`.
+ *    If no aggregator is set, the raw chunk list is recorded.
+ *
+ * On `stream()`:
+ * - Delegates to the underlying `stream()` each call (fresh stream per call).
+ * - Chunks are collected via `peek()` and reset on each `stream()` call to avoid double-counting.
+ * - The returned stream wraps a [errorCapturingStream] spliterator that captures iteration errors.
  */
 private fun createTracedStreamProxy(
     delegate: AutoCloseable,
@@ -759,45 +766,66 @@ private fun createTracedStreamProxy(
         args ->
         when (method.name) {
             "stream" -> {
+                // Clear chunks so repeated stream() calls don't double-count.
+                chunks.clear()
+                iterationError.set(null)
                 // Delegate to the underlying stream() each call (preserves fresh-stream semantics).
-                // Wrap with peek() to collect chunks. Use a wrapping Spliterator to catch errors
-                // during iteration so close() can record them on the run.
-                val raw = streamMethod.invoke(delegate) as java.util.stream.Stream<*>
+                val raw = invokeUnwrapping(streamMethod, delegate) as java.util.stream.Stream<*>
                 errorCapturingStream(raw.peek { chunks.add(it) }, iterationError)
             }
             "close" -> {
                 if (closed.compareAndSet(false, true)) {
+                    // Close the delegate first — if cleanup fails, record that as the error.
+                    var closeError: Throwable? = null
                     try {
-                        val error = iterationError.get()
+                        delegate.close()
+                    } catch (e: Throwable) {
+                        closeError = e
+                    }
+
+                    try {
+                        val error = iterationError.get() ?: closeError
                         if (error != null) {
                             run.endTime = nowIso()
                             run.error = error.stackTraceToString()
-                            run.patchRun()
                         } else {
                             val aggregator = config.processTracedIO?.aggregatorFn
                             val output =
                                 if (aggregator != null) aggregator.apply(chunks)
                                 else chunks.toList()
                             run.endTime = nowIso()
-                            run.outputs =
-                                applyProcessOutputs(config, output) ?: toOutputMap(output)
-                            run.patchRun()
+                            run.outputs = applyProcessOutputs(config, output) ?: toOutputMap(output)
                         }
+                        run.patchRun()
                     } catch (e: Throwable) {
                         run.endTime = nowIso()
                         run.error = e.stackTraceToString()
                         run.patchRun()
-                    } finally {
-                        delegate.close()
                     }
+
+                    // Rethrow close error so caller sees the failure
+                    if (closeError != null) throw closeError
                 }
             }
             else -> {
-                if (args != null) method.invoke(delegate, *args) else method.invoke(delegate)
+                // Unwrap InvocationTargetException so callers see the original exception
+                invokeUnwrapping(method, delegate, args)
             }
         }
     }
 }
+
+/** Invokes a method via reflection, unwrapping [java.lang.reflect.InvocationTargetException]. */
+private fun invokeUnwrapping(
+    method: java.lang.reflect.Method,
+    target: Any,
+    args: Array<out Any?>? = null,
+): Any? =
+    try {
+        if (args != null) method.invoke(target, *args) else method.invoke(target)
+    } catch (e: java.lang.reflect.InvocationTargetException) {
+        throw e.cause ?: e
+    }
 
 /**
  * Wraps a [java.util.stream.Stream] so that exceptions thrown during iteration (e.g. inside
@@ -820,7 +848,9 @@ private fun errorCapturingStream(
                 }
 
             override fun trySplit(): java.util.Spliterator<Any?>? = null
+
             override fun estimateSize(): Long = sourceSpliterator.estimateSize()
+
             override fun characteristics(): Int = sourceSpliterator.characteristics()
         }
     return java.util.stream.StreamSupport.stream(wrapping, false).onClose { source.close() }

--- a/langsmith-java-core/src/main/kotlin/com/langchain/smith/tracing/Traceable.kt
+++ b/langsmith-java-core/src/main/kotlin/com/langchain/smith/tracing/Traceable.kt
@@ -695,7 +695,8 @@ private fun <T> executeTraced(config: TraceConfig, inputs: Map<String, Any?>?, b
                 val iterationError = java.util.concurrent.atomic.AtomicReference<Throwable>(null)
                 val streamExhausted = java.util.concurrent.atomic.AtomicBoolean(false)
                 val instrumented =
-                    result.withErrorTracking(iterationError, streamExhausted)
+                    result
+                        .withErrorTracking(iterationError, streamExhausted)
                         .peek { chunks.add(it) }
                         .onClose {
                             try {
@@ -747,9 +748,9 @@ private fun <T> executeTraced(config: TraceConfig, inputs: Map<String, Any?>?, b
 }
 
 /**
- * Returns a new [java.util.stream.Stream] that captures exceptions during iteration into
- * [errorRef] before rethrowing them. This lets the `onClose` handler record the real error instead
- * of attempting aggregation on partial data.
+ * Returns a new [java.util.stream.Stream] that captures exceptions during iteration into [errorRef]
+ * before rethrowing them. This lets the `onClose` handler record the real error instead of
+ * attempting aggregation on partial data.
  */
 private fun java.util.stream.Stream<*>.withErrorTracking(
     errorRef: java.util.concurrent.atomic.AtomicReference<Throwable>,

--- a/langsmith-java-core/src/main/kotlin/com/langchain/smith/tracing/Traceable.kt
+++ b/langsmith-java-core/src/main/kotlin/com/langchain/smith/tracing/Traceable.kt
@@ -687,11 +687,11 @@ private fun <T> executeTraced(config: TraceConfig, inputs: Map<String, Any?>?, b
         try {
             val result = block()
 
-            // If the result is an interface-based AutoCloseable with a stream() method
-            // returning java.util.stream.Stream, wrap it in a proxy that defers run
-            // completion until close(). See TraceProcessIO.aggregatorFn for details.
+            // Only wrap stream-like results when the caller explicitly opted in by setting
+            // an aggregator on TraceProcessIO. Without an aggregator, the return value is
+            // treated normally (recorded immediately, run completed on return).
             val streamMethod =
-                if (result is AutoCloseable) {
+                if (config.processTracedIO?.aggregatorFn != null && result is AutoCloseable) {
                     try {
                         result::class.java.getMethod("stream").takeIf {
                             java.util.stream.Stream::class.java.isAssignableFrom(it.returnType)
@@ -764,8 +764,8 @@ private fun createTracedStreamProxy(
         _,
         method,
         args ->
-        when (method.name) {
-            "stream" -> {
+        when {
+            method.name == "stream" && method.parameterCount == 0 -> {
                 // Clear chunks so repeated stream() calls don't double-count.
                 chunks.clear()
                 iterationError.set(null)
@@ -773,7 +773,7 @@ private fun createTracedStreamProxy(
                 val raw = invokeUnwrapping(streamMethod, delegate) as java.util.stream.Stream<*>
                 errorCapturingStream(raw.peek { chunks.add(it) }, iterationError)
             }
-            "close" -> {
+            method.name == "close" && method.parameterCount == 0 -> {
                 if (closed.compareAndSet(false, true)) {
                     // Close the delegate first — if cleanup fails, record that as the error.
                     var closeError: Throwable? = null
@@ -789,10 +789,8 @@ private fun createTracedStreamProxy(
                             run.endTime = nowIso()
                             run.error = error.stackTraceToString()
                         } else {
-                            val aggregator = config.processTracedIO?.aggregatorFn
-                            val output =
-                                if (aggregator != null) aggregator.apply(chunks)
-                                else chunks.toList()
+                            val aggregator = config.processTracedIO!!.aggregatorFn!!
+                            val output = aggregator.apply(chunks)
                             run.endTime = nowIso()
                             run.outputs = applyProcessOutputs(config, output) ?: toOutputMap(output)
                         }

--- a/langsmith-java-core/src/main/kotlin/com/langchain/smith/tracing/Traceable.kt
+++ b/langsmith-java-core/src/main/kotlin/com/langchain/smith/tracing/Traceable.kt
@@ -695,7 +695,7 @@ private fun <T> executeTraced(config: TraceConfig, inputs: Map<String, Any?>?, b
                 val iterationError = java.util.concurrent.atomic.AtomicReference<Throwable>(null)
                 val streamExhausted = java.util.concurrent.atomic.AtomicBoolean(false)
                 val instrumented =
-                    wrapStreamWithErrorCapture(result, iterationError, streamExhausted)
+                    result.withErrorTracking(iterationError, streamExhausted)
                         .peek { chunks.add(it) }
                         .onClose {
                             try {
@@ -747,16 +747,15 @@ private fun <T> executeTraced(config: TraceConfig, inputs: Map<String, Any?>?, b
 }
 
 /**
- * Wraps a [java.util.stream.Stream] so that exceptions during iteration are captured into
- * [errorRef] before being rethrown. This lets the `onClose` handler record the real error instead
+ * Returns a new [java.util.stream.Stream] that captures exceptions during iteration into
+ * [errorRef] before rethrowing them. This lets the `onClose` handler record the real error instead
  * of attempting aggregation on partial data.
  */
-private fun wrapStreamWithErrorCapture(
-    source: java.util.stream.Stream<*>,
+private fun java.util.stream.Stream<*>.withErrorTracking(
     errorRef: java.util.concurrent.atomic.AtomicReference<Throwable>,
     exhaustedRef: java.util.concurrent.atomic.AtomicBoolean,
 ): java.util.stream.Stream<Any?> {
-    val delegate = source.spliterator()
+    val delegate = this.spliterator()
     val capturing =
         object : java.util.Spliterator<Any?> {
             override fun tryAdvance(action: java.util.function.Consumer<in Any?>): Boolean =
@@ -773,5 +772,5 @@ private fun wrapStreamWithErrorCapture(
 
             override fun characteristics(): Int = delegate.characteristics()
         }
-    return java.util.stream.StreamSupport.stream(capturing, false).onClose { source.close() }
+    return java.util.stream.StreamSupport.stream(capturing, false).onClose { this.close() }
 }

--- a/langsmith-java-core/src/test/kotlin/com/langchain/smith/tracing/TraceableStreamingTest.kt
+++ b/langsmith-java-core/src/test/kotlin/com/langchain/smith/tracing/TraceableStreamingTest.kt
@@ -3,61 +3,12 @@ package com.langchain.smith.tracing
 import java.util.stream.Collectors
 import java.util.stream.Stream
 import org.assertj.core.api.Assertions.assertThat
-import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.Test
 
 /** Unit tests for streaming support in [traceable]. */
 internal class TraceableStreamingTest {
 
-    interface StreamLike<T> : AutoCloseable {
-        fun stream(): Stream<T>
-    }
-
-    private fun fakeStream(items: List<String>): StreamLike<String> =
-        object : StreamLike<String> {
-            override fun stream(): Stream<String> = items.stream()
-
-            override fun close() {}
-        }
-
-    private fun failingStream(): StreamLike<String> =
-        object : StreamLike<String> {
-            override fun stream(): Stream<String> =
-                Stream.of("ok", "boom").map {
-                    if (it == "boom") throw RuntimeException("stream failed")
-                    it
-                }
-
-            override fun close() {}
-        }
-
-    private fun failingCloseStream(): StreamLike<String> =
-        object : StreamLike<String> {
-            override fun stream(): Stream<String> = listOf("a", "b").stream()
-
-            override fun close() {
-                throw RuntimeException("close failed")
-            }
-        }
-
     private fun parentRun() = RunTree(name = "parent", runType = RunType.CHAIN)
-
-    /** Traces a function, capturing the child [RunTree] for inspection. */
-    private fun traceCapturingRun(
-        config: TraceConfig,
-        streamFactory: () -> StreamLike<String>,
-    ): Pair<(String) -> StreamLike<String>, () -> RunTree?> {
-        var childRun: RunTree? = null
-        val traced =
-            traceable(
-                { _: String ->
-                    childRun = getCurrentRunTree()
-                    streamFactory()
-                },
-                config,
-            )
-        return traced to { childRun }
-    }
 
     private fun configWithAggregator(): TraceConfig =
         TraceConfig.builder()
@@ -70,137 +21,69 @@ internal class TraceableStreamingTest {
             )
             .build()
 
+    /** Traces a function returning a Stream, capturing the child RunTree for inspection. */
+    private fun traceCapturingRun(
+        config: TraceConfig,
+        streamFactory: () -> Stream<String>,
+    ): Pair<(String) -> Stream<String>, () -> RunTree?> {
+        var childRun: RunTree? = null
+        val traced =
+            traceable(
+                { _: String ->
+                    childRun = getCurrentRunTree()
+                    streamFactory()
+                },
+                config,
+            )
+        return traced to { childRun }
+    }
+
     @Test
     fun `stream passthrough when tracing disabled`() {
         val config = TraceConfig.builder().name("test").tracingEnabled(false).build()
-        val traced = traceable({ _: String -> fakeStream(listOf("a", "b", "c")) }, config)
+        val traced = traceable({ _: String -> Stream.of("a", "b", "c") }, config)
 
-        val result = traced("input")
-        val collected = result.stream().collect(Collectors.toList())
-        result.close()
+        val collected = traced("input").collect(Collectors.toList())
 
         assertThat(collected).isEqualTo(listOf("a", "b", "c"))
     }
 
     @Test
-    fun `stream proxy collects chunks and aggregates on close`() {
+    fun `non-stream return is not affected by aggregator`() {
+        val config =
+            TraceConfig.builder()
+                .name("non-stream")
+                .tracingEnabled(true)
+                .processTracedIO(
+                    TraceProcessIO<String, Any>(aggregator = java.util.function.Function { it })
+                )
+                .build()
+
+        withParent(parentRun()) {
+            val traced = traceable({ input: String -> input.uppercase() }, config)
+            val result = traced("hello")
+
+            assertThat(result).isEqualTo("HELLO")
+        }
+    }
+
+    @Test
+    fun `stream is instrumented and aggregated on close`() {
         val config = configWithAggregator()
 
         withParent(parentRun()) {
-            val (traced, getRun) = traceCapturingRun(config) { fakeStream(listOf("x", "y", "z")) }
+            val (traced, getRun) = traceCapturingRun(config) { Stream.of("x", "y", "z") }
             val stream = traced("input")
-            stream.stream().collect(Collectors.toList())
+            val collected = stream.collect(Collectors.toList())
             stream.close()
+
+            assertThat(collected).isEqualTo(listOf("x", "y", "z"))
 
             val run = getRun()!!
             assertThat(run.endTime).isNotNull()
             assertThat(run.outputs).isNotNull()
             assertThat(run.outputs!!["outputs"]).isEqualTo("xyz")
             assertThat(run.error).isNull()
-        }
-    }
-
-    @Test
-    fun `no aggregator means no stream wrapping`() {
-        val config = TraceConfig.builder().name("no-agg").tracingEnabled(true).build()
-
-        withParent(parentRun()) {
-            val (traced, getRun) = traceCapturingRun(config) { fakeStream(listOf("a", "b")) }
-            val stream = traced("input")
-
-            // Without an aggregator, the result is not proxied — run completes immediately
-            assertThat(java.lang.reflect.Proxy.isProxyClass(stream::class.java)).isFalse()
-
-            val run = getRun()!!
-            assertThat(run.endTime).isNotNull()
-        }
-    }
-
-    @Test
-    fun `repeated stream() calls only count last consumption`() {
-        val config = configWithAggregator()
-
-        withParent(parentRun()) {
-            val (traced, getRun) = traceCapturingRun(config) { fakeStream(listOf("a", "b")) }
-            val stream = traced("input")
-
-            stream.stream().collect(Collectors.toList())
-            stream.stream().collect(Collectors.toList())
-            stream.close()
-
-            val run = getRun()!!
-            // Should be "ab" not "abab" — chunks reset on each stream() call
-            assertThat(run.outputs!!["outputs"]).isEqualTo("ab")
-        }
-    }
-
-    @Test
-    fun `close is idempotent`() {
-        val config = configWithAggregator()
-
-        withParent(parentRun()) {
-            val (traced, getRun) = traceCapturingRun(config) { fakeStream(listOf("a")) }
-            val stream = traced("input")
-            stream.stream().collect(Collectors.toList())
-
-            stream.close()
-            stream.close()
-
-            val run = getRun()!!
-            assertThat(run.endTime).isNotNull()
-        }
-    }
-
-    @Test
-    fun `non-stream AutoCloseable is not wrapped`() {
-        val config = TraceConfig.builder().name("non-stream").tracingEnabled(true).build()
-
-        val closeable =
-            object : AutoCloseable {
-                override fun close() {}
-
-                override fun toString() = "not-a-stream"
-            }
-
-        withParent(parentRun()) {
-            val traced = traceable({ _: String -> closeable }, config)
-            val result = traced("input")
-
-            assertThat(java.lang.reflect.Proxy.isProxyClass(result::class.java)).isFalse()
-        }
-    }
-
-    @Test
-    fun `stream proxy implements same interfaces as delegate`() {
-        val config = configWithAggregator()
-
-        withParent(parentRun()) {
-            val traced = traceable({ _: String -> fakeStream(listOf("a")) }, config)
-            val result = traced("input")
-
-            assertThat(result).isInstanceOf(StreamLike::class.java)
-            assertThat(result).isInstanceOf(AutoCloseable::class.java)
-
-            result.stream().collect(Collectors.toList())
-            result.close()
-        }
-    }
-
-    @Test
-    fun `iteration error is captured on run`() {
-        val config = configWithAggregator()
-
-        withParent(parentRun()) {
-            val (traced, getRun) = traceCapturingRun(config) { failingStream() }
-            val stream = traced("input")
-            try {
-                stream.stream().collect(Collectors.toList())
-            } catch (_: RuntimeException) {}
-            stream.close()
-
-            val run = getRun()!!
-            assertThat(run.endTime).isNotNull()
-            assertThat(run.error).contains("stream failed")
         }
     }
 
@@ -219,9 +102,9 @@ internal class TraceableStreamingTest {
                 .build()
 
         withParent(parentRun()) {
-            val (traced, getRun) = traceCapturingRun(config) { fakeStream(listOf("a")) }
+            val (traced, getRun) = traceCapturingRun(config) { Stream.of("a") }
             val stream = traced("input")
-            stream.stream().collect(Collectors.toList())
+            stream.collect(Collectors.toList())
             stream.close()
 
             val run = getRun()!!
@@ -231,21 +114,60 @@ internal class TraceableStreamingTest {
     }
 
     @Test
-    fun `delegate close error is recorded on run and rethrown`() {
+    fun `iteration error is recorded on run`() {
         val config = configWithAggregator()
 
         withParent(parentRun()) {
-            val (traced, getRun) = traceCapturingRun(config) { failingCloseStream() }
+            val (traced, getRun) =
+                traceCapturingRun(config) {
+                    Stream.of("ok", "boom").map {
+                        if (it == "boom") throw RuntimeException("stream failed")
+                        it
+                    }
+                }
             val stream = traced("input")
-            stream.stream().collect(Collectors.toList())
-
-            assertThatThrownBy { stream.close() }
-                .isInstanceOf(RuntimeException::class.java)
-                .hasMessage("close failed")
+            try {
+                stream.collect(Collectors.toList())
+            } catch (_: RuntimeException) {}
+            stream.close()
 
             val run = getRun()!!
             assertThat(run.endTime).isNotNull()
-            assertThat(run.error).contains("close failed")
+            assertThat(run.error).contains("stream failed")
+        }
+    }
+
+    @Test
+    fun `return type is a real Stream not a proxy`() {
+        val config = configWithAggregator()
+
+        withParent(parentRun()) {
+            val traced = traceable({ _: String -> Stream.of("a") }, config)
+            val result = traced("input")
+
+            assertThat(result).isInstanceOf(Stream::class.java)
+            assertThat(java.lang.reflect.Proxy.isProxyClass(result::class.java)).isFalse()
+
+            result.collect(Collectors.toList())
+            result.close()
+        }
+    }
+
+    @Test
+    fun `without aggregator stream return completes run immediately`() {
+        val config = TraceConfig.builder().name("no-agg").tracingEnabled(true).build()
+
+        withParent(parentRun()) {
+            val (traced, getRun) = traceCapturingRun(config) { Stream.of("a", "b") }
+            val stream = traced("input")
+
+            // Run should be completed immediately (no deferred close)
+            val run = getRun()!!
+            assertThat(run.endTime).isNotNull()
+
+            // Stream still works
+            val collected = stream.collect(Collectors.toList())
+            assertThat(collected).isEqualTo(listOf("a", "b"))
         }
     }
 }

--- a/langsmith-java-core/src/test/kotlin/com/langchain/smith/tracing/TraceableStreamingTest.kt
+++ b/langsmith-java-core/src/test/kotlin/com/langchain/smith/tracing/TraceableStreamingTest.kt
@@ -101,19 +101,18 @@ internal class TraceableStreamingTest {
     }
 
     @Test
-    fun `stream proxy records raw chunks when no aggregator set`() {
+    fun `no aggregator means no stream wrapping`() {
         val config = TraceConfig.builder().name("no-agg").tracingEnabled(true).build()
 
         withParent(parentRun()) {
             val (traced, getRun) = traceCapturingRun(config) { fakeStream(listOf("a", "b")) }
             val stream = traced("input")
-            stream.stream().collect(Collectors.toList())
-            stream.close()
+
+            // Without an aggregator, the result is not proxied — run completes immediately
+            assertThat(java.lang.reflect.Proxy.isProxyClass(stream::class.java)).isFalse()
 
             val run = getRun()!!
             assertThat(run.endTime).isNotNull()
-            assertThat(run.outputs!!["outputs"]).isEqualTo(listOf("a", "b"))
-            assertThat(run.error).isNull()
         }
     }
 

--- a/langsmith-java-core/src/test/kotlin/com/langchain/smith/tracing/TraceableStreamingTest.kt
+++ b/langsmith-java-core/src/test/kotlin/com/langchain/smith/tracing/TraceableStreamingTest.kt
@@ -154,6 +154,29 @@ internal class TraceableStreamingTest {
     }
 
     @Test
+    fun `early close records partial chunks`() {
+        val config = configWithAggregator()
+
+        withParent(parentRun()) {
+            val (traced, getRun) = traceCapturingRun(config) { Stream.of("a", "b", "c", "d", "e") }
+            val stream = traced("input")
+
+            // Consume only first 2 elements then close
+            val iter = stream.iterator()
+            val partial = listOf(iter.next(), iter.next())
+            stream.close()
+
+            assertThat(partial).isEqualTo(listOf("a", "b"))
+
+            val run = getRun()!!
+            assertThat(run.endTime).isNotNull()
+            assertThat(run.error).isEqualTo("Stream cancelled")
+            // Partial output is still aggregated
+            assertThat(run.outputs!!["outputs"]).isEqualTo("ab")
+        }
+    }
+
+    @Test
     fun `without aggregator stream return completes run immediately`() {
         val config = TraceConfig.builder().name("no-agg").tracingEnabled(true).build()
 

--- a/langsmith-java-core/src/test/kotlin/com/langchain/smith/tracing/TraceableStreamingTest.kt
+++ b/langsmith-java-core/src/test/kotlin/com/langchain/smith/tracing/TraceableStreamingTest.kt
@@ -1,0 +1,234 @@
+package com.langchain.smith.tracing
+
+import java.util.stream.Collectors
+import java.util.stream.Stream
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+/** Unit tests for streaming support in [traceable]. */
+internal class TraceableStreamingTest {
+
+    /** Minimal AutoCloseable with a `stream()` method, mimicking OpenAI's StreamResponse. */
+    interface StreamLike<T> : AutoCloseable {
+        fun stream(): Stream<T>
+    }
+
+    private fun fakeStream(items: List<String>): StreamLike<String> =
+        object : StreamLike<String> {
+            override fun stream(): Stream<String> = items.stream()
+
+            override fun close() {}
+        }
+
+    private fun failingStream(): StreamLike<String> =
+        object : StreamLike<String> {
+            override fun stream(): Stream<String> =
+                Stream.of("ok", "boom").map {
+                    if (it == "boom") throw RuntimeException("stream failed")
+                    it
+                }
+
+            override fun close() {}
+        }
+
+    private fun parentRun() = RunTree(name = "parent", runType = RunType.CHAIN)
+
+    private fun configWithAggregator(
+        capturedOutputs: MutableList<Map<String, Any?>>? = null
+    ): TraceConfig =
+        TraceConfig.builder()
+            .name("stream-test")
+            .tracingEnabled(true)
+            .processTracedIO(
+                TraceProcessIO<String, Any>(
+                    aggregator = java.util.function.Function { chunks -> chunks.joinToString("") },
+                    processOutputs =
+                        java.util.function.Function { output ->
+                            val map = mapOf("result" to output)
+                            capturedOutputs?.add(map)
+                            map
+                        },
+                )
+            )
+            .build()
+
+    @Test
+    fun `stream passthrough when tracing disabled`() {
+        val config = TraceConfig.builder().name("test").tracingEnabled(false).build()
+        val traced = traceable({ _: String -> fakeStream(listOf("a", "b", "c")) }, config)
+
+        val result = traced("input")
+        val collected = result.stream().collect(Collectors.toList())
+        result.close()
+
+        assertThat(collected).isEqualTo(listOf("a", "b", "c"))
+    }
+
+    @Test
+    fun `stream proxy collects chunks and aggregates on close`() {
+        val capturedOutputs = mutableListOf<Map<String, Any?>>()
+        val config = configWithAggregator(capturedOutputs)
+
+        withParent(parentRun()) {
+            val traced = traceable({ _: String -> fakeStream(listOf("x", "y", "z")) }, config)
+            val stream = traced("input")
+            stream.stream().collect(Collectors.toList())
+            stream.close()
+        }
+
+        assertThat(capturedOutputs).hasSize(1)
+        assertThat(capturedOutputs[0]["result"]).isEqualTo("xyz")
+    }
+
+    @Test
+    fun `stream proxy records raw chunks when no aggregator set`() {
+        val capturedOutputs = mutableListOf<Map<String, Any?>>()
+        val config =
+            TraceConfig.builder()
+                .name("no-agg")
+                .tracingEnabled(true)
+                .processTracedIO(
+                    TraceProcessIO<String, Any>(
+                        processOutputs =
+                            java.util.function.Function { output ->
+                                val map = mapOf("result" to output)
+                                capturedOutputs.add(map)
+                                map
+                            }
+                    )
+                )
+                .build()
+
+        withParent(parentRun()) {
+            val traced = traceable({ _: String -> fakeStream(listOf("a", "b")) }, config)
+            val stream = traced("input")
+            stream.stream().collect(Collectors.toList())
+            stream.close()
+        }
+
+        assertThat(capturedOutputs).hasSize(1)
+        assertThat(capturedOutputs[0]["result"]).isEqualTo(listOf("a", "b"))
+    }
+
+    @Test
+    fun `stream() returns fresh stream per call`() {
+        val config = configWithAggregator()
+
+        withParent(parentRun()) {
+            val traced = traceable({ _: String -> fakeStream(listOf("a", "b")) }, config)
+            val stream = traced("input")
+
+            val first = stream.stream().collect(Collectors.toList())
+            val second = stream.stream().collect(Collectors.toList())
+
+            assertThat(first).isEqualTo(listOf("a", "b"))
+            assertThat(second).isEqualTo(listOf("a", "b"))
+            stream.close()
+        }
+    }
+
+    @Test
+    fun `close is idempotent`() {
+        val capturedOutputs = mutableListOf<Map<String, Any?>>()
+        val config = configWithAggregator(capturedOutputs)
+
+        withParent(parentRun()) {
+            val traced = traceable({ _: String -> fakeStream(listOf("a")) }, config)
+            val stream = traced("input")
+            stream.stream().collect(Collectors.toList())
+
+            stream.close()
+            stream.close()
+        }
+
+        assertThat(capturedOutputs).hasSize(1)
+    }
+
+    @Test
+    fun `non-stream AutoCloseable is not wrapped`() {
+        val config = TraceConfig.builder().name("non-stream").tracingEnabled(true).build()
+
+        val closeable =
+            object : AutoCloseable {
+                override fun close() {}
+
+                override fun toString() = "not-a-stream"
+            }
+
+        withParent(parentRun()) {
+            val traced = traceable({ _: String -> closeable }, config)
+            val result = traced("input")
+
+            assertThat(java.lang.reflect.Proxy.isProxyClass(result::class.java)).isFalse()
+        }
+    }
+
+    @Test
+    fun `stream proxy implements same interfaces as delegate`() {
+        val config = configWithAggregator()
+
+        withParent(parentRun()) {
+            val traced = traceable({ _: String -> fakeStream(listOf("a")) }, config)
+            val result = traced("input")
+
+            assertThat(result).isInstanceOf(StreamLike::class.java)
+            assertThat(result).isInstanceOf(AutoCloseable::class.java)
+
+            result.stream().collect(Collectors.toList())
+            result.close()
+        }
+    }
+
+    @Test
+    fun `iteration error is captured on close`() {
+        val config =
+            TraceConfig.builder()
+                .name("iter-error")
+                .tracingEnabled(true)
+                .processTracedIO(
+                    TraceProcessIO<String, Any>(
+                        aggregator = java.util.function.Function { it },
+                    )
+                )
+                .build()
+
+        withParent(parentRun()) {
+            val traced =
+                traceable(
+                    { _: String -> failingStream() },
+                    config,
+                )
+            val stream = traced("input")
+            try {
+                stream.stream().collect(Collectors.toList())
+            } catch (_: RuntimeException) {
+                // expected
+            }
+            // close() should record the error, not throw
+            stream.close()
+        }
+    }
+
+    @Test
+    fun `aggregator error is captured in run`() {
+        val config =
+            TraceConfig.builder()
+                .name("bad-agg")
+                .tracingEnabled(true)
+                .processTracedIO(
+                    TraceProcessIO<String, StreamLike<String>>(
+                        aggregator =
+                            java.util.function.Function { throw RuntimeException("agg failed") }
+                    )
+                )
+                .build()
+
+        withParent(parentRun()) {
+            val traced = traceable({ _: String -> fakeStream(listOf("a")) }, config)
+            val stream = traced("input")
+            stream.stream().collect(Collectors.toList())
+            // close() should not throw — error is captured on the run
+            stream.close()
+        }
+    }
+}

--- a/langsmith-java-core/src/test/kotlin/com/langchain/smith/tracing/TraceableStreamingTest.kt
+++ b/langsmith-java-core/src/test/kotlin/com/langchain/smith/tracing/TraceableStreamingTest.kt
@@ -3,12 +3,12 @@ package com.langchain.smith.tracing
 import java.util.stream.Collectors
 import java.util.stream.Stream
 import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.Test
 
 /** Unit tests for streaming support in [traceable]. */
 internal class TraceableStreamingTest {
 
-    /** Minimal AutoCloseable with a `stream()` method, mimicking OpenAI's StreamResponse. */
     interface StreamLike<T> : AutoCloseable {
         fun stream(): Stream<T>
     }
@@ -31,23 +31,41 @@ internal class TraceableStreamingTest {
             override fun close() {}
         }
 
+    private fun failingCloseStream(): StreamLike<String> =
+        object : StreamLike<String> {
+            override fun stream(): Stream<String> = listOf("a", "b").stream()
+
+            override fun close() {
+                throw RuntimeException("close failed")
+            }
+        }
+
     private fun parentRun() = RunTree(name = "parent", runType = RunType.CHAIN)
 
-    private fun configWithAggregator(
-        capturedOutputs: MutableList<Map<String, Any?>>? = null
-    ): TraceConfig =
+    /** Traces a function, capturing the child [RunTree] for inspection. */
+    private fun traceCapturingRun(
+        config: TraceConfig,
+        streamFactory: () -> StreamLike<String>,
+    ): Pair<(String) -> StreamLike<String>, () -> RunTree?> {
+        var childRun: RunTree? = null
+        val traced =
+            traceable(
+                { _: String ->
+                    childRun = getCurrentRunTree()
+                    streamFactory()
+                },
+                config,
+            )
+        return traced to { childRun }
+    }
+
+    private fun configWithAggregator(): TraceConfig =
         TraceConfig.builder()
             .name("stream-test")
             .tracingEnabled(true)
             .processTracedIO(
                 TraceProcessIO<String, Any>(
-                    aggregator = java.util.function.Function { chunks -> chunks.joinToString("") },
-                    processOutputs =
-                        java.util.function.Function { output ->
-                            val map = mapOf("result" to output)
-                            capturedOutputs?.add(map)
-                            map
-                        },
+                    aggregator = java.util.function.Function { chunks -> chunks.joinToString("") }
                 )
             )
             .build()
@@ -66,82 +84,72 @@ internal class TraceableStreamingTest {
 
     @Test
     fun `stream proxy collects chunks and aggregates on close`() {
-        val capturedOutputs = mutableListOf<Map<String, Any?>>()
-        val config = configWithAggregator(capturedOutputs)
+        val config = configWithAggregator()
 
         withParent(parentRun()) {
-            val traced = traceable({ _: String -> fakeStream(listOf("x", "y", "z")) }, config)
+            val (traced, getRun) = traceCapturingRun(config) { fakeStream(listOf("x", "y", "z")) }
             val stream = traced("input")
             stream.stream().collect(Collectors.toList())
             stream.close()
-        }
 
-        assertThat(capturedOutputs).hasSize(1)
-        assertThat(capturedOutputs[0]["result"]).isEqualTo("xyz")
+            val run = getRun()!!
+            assertThat(run.endTime).isNotNull()
+            assertThat(run.outputs).isNotNull()
+            assertThat(run.outputs!!["outputs"]).isEqualTo("xyz")
+            assertThat(run.error).isNull()
+        }
     }
 
     @Test
     fun `stream proxy records raw chunks when no aggregator set`() {
-        val capturedOutputs = mutableListOf<Map<String, Any?>>()
-        val config =
-            TraceConfig.builder()
-                .name("no-agg")
-                .tracingEnabled(true)
-                .processTracedIO(
-                    TraceProcessIO<String, Any>(
-                        processOutputs =
-                            java.util.function.Function { output ->
-                                val map = mapOf("result" to output)
-                                capturedOutputs.add(map)
-                                map
-                            }
-                    )
-                )
-                .build()
+        val config = TraceConfig.builder().name("no-agg").tracingEnabled(true).build()
 
         withParent(parentRun()) {
-            val traced = traceable({ _: String -> fakeStream(listOf("a", "b")) }, config)
+            val (traced, getRun) = traceCapturingRun(config) { fakeStream(listOf("a", "b")) }
             val stream = traced("input")
             stream.stream().collect(Collectors.toList())
             stream.close()
-        }
 
-        assertThat(capturedOutputs).hasSize(1)
-        assertThat(capturedOutputs[0]["result"]).isEqualTo(listOf("a", "b"))
+            val run = getRun()!!
+            assertThat(run.endTime).isNotNull()
+            assertThat(run.outputs!!["outputs"]).isEqualTo(listOf("a", "b"))
+            assertThat(run.error).isNull()
+        }
     }
 
     @Test
-    fun `stream() returns fresh stream per call`() {
+    fun `repeated stream() calls only count last consumption`() {
         val config = configWithAggregator()
 
         withParent(parentRun()) {
-            val traced = traceable({ _: String -> fakeStream(listOf("a", "b")) }, config)
+            val (traced, getRun) = traceCapturingRun(config) { fakeStream(listOf("a", "b")) }
             val stream = traced("input")
 
-            val first = stream.stream().collect(Collectors.toList())
-            val second = stream.stream().collect(Collectors.toList())
-
-            assertThat(first).isEqualTo(listOf("a", "b"))
-            assertThat(second).isEqualTo(listOf("a", "b"))
+            stream.stream().collect(Collectors.toList())
+            stream.stream().collect(Collectors.toList())
             stream.close()
+
+            val run = getRun()!!
+            // Should be "ab" not "abab" — chunks reset on each stream() call
+            assertThat(run.outputs!!["outputs"]).isEqualTo("ab")
         }
     }
 
     @Test
     fun `close is idempotent`() {
-        val capturedOutputs = mutableListOf<Map<String, Any?>>()
-        val config = configWithAggregator(capturedOutputs)
+        val config = configWithAggregator()
 
         withParent(parentRun()) {
-            val traced = traceable({ _: String -> fakeStream(listOf("a")) }, config)
+            val (traced, getRun) = traceCapturingRun(config) { fakeStream(listOf("a")) }
             val stream = traced("input")
             stream.stream().collect(Collectors.toList())
 
             stream.close()
             stream.close()
-        }
 
-        assertThat(capturedOutputs).hasSize(1)
+            val run = getRun()!!
+            assertThat(run.endTime).isNotNull()
+        }
     }
 
     @Test
@@ -180,43 +188,31 @@ internal class TraceableStreamingTest {
     }
 
     @Test
-    fun `iteration error is captured on close`() {
-        val config =
-            TraceConfig.builder()
-                .name("iter-error")
-                .tracingEnabled(true)
-                .processTracedIO(
-                    TraceProcessIO<String, Any>(
-                        aggregator = java.util.function.Function { it },
-                    )
-                )
-                .build()
+    fun `iteration error is captured on run`() {
+        val config = configWithAggregator()
 
         withParent(parentRun()) {
-            val traced =
-                traceable(
-                    { _: String -> failingStream() },
-                    config,
-                )
+            val (traced, getRun) = traceCapturingRun(config) { failingStream() }
             val stream = traced("input")
             try {
                 stream.stream().collect(Collectors.toList())
-            } catch (_: RuntimeException) {
-                // expected
-            }
-            // close() should record the error, not throw
+            } catch (_: RuntimeException) {}
             stream.close()
+
+            val run = getRun()!!
+            assertThat(run.endTime).isNotNull()
+            assertThat(run.error).contains("stream failed")
         }
     }
 
     @Test
-    fun `aggregator error is captured in run`() {
+    fun `aggregator error is captured on run`() {
         val config =
             TraceConfig.builder()
                 .name("bad-agg")
                 .tracingEnabled(true)
                 .processTracedIO(
-                    TraceProcessIO<String, StreamLike<String>>(
+                    TraceProcessIO<String, Any>(
                         aggregator =
                             java.util.function.Function { throw RuntimeException("agg failed") }
                     )
@@ -224,11 +220,33 @@ internal class TraceableStreamingTest {
                 .build()
 
         withParent(parentRun()) {
-            val traced = traceable({ _: String -> fakeStream(listOf("a")) }, config)
+            val (traced, getRun) = traceCapturingRun(config) { fakeStream(listOf("a")) }
             val stream = traced("input")
             stream.stream().collect(Collectors.toList())
-            // close() should not throw — error is captured on the run
             stream.close()
+
+            val run = getRun()!!
+            assertThat(run.endTime).isNotNull()
+            assertThat(run.error).contains("agg failed")
+        }
+    }
+
+    @Test
+    fun `delegate close error is recorded on run and rethrown`() {
+        val config = configWithAggregator()
+
+        withParent(parentRun()) {
+            val (traced, getRun) = traceCapturingRun(config) { failingCloseStream() }
+            val stream = traced("input")
+            stream.stream().collect(Collectors.toList())
+
+            assertThatThrownBy { stream.close() }
+                .isInstanceOf(RuntimeException::class.java)
+                .hasMessage("close failed")
+
+            val run = getRun()!!
+            assertThat(run.endTime).isNotNull()
+            assertThat(run.error).contains("close failed")
         }
     }
 }


### PR DESCRIPTION
Adds opt-in support for tracing `java.util.stream.Stream` returns in `traceable`. Will be used in `wrapOpenAI` and other premade instrumentations for client libraries.

## Usage

```kotlin
val config = TraceConfig.builder()
    .name("my-stream")
    .processTracedIO(
        TraceProcessIO.builder<String, Any>()
            .aggregator(Function { chunks -> chunks.joinToString("") })
            .build()
    )
    .build()

val traced = traceable({ input: String -> someStreamingApi(input) }, config)

traced("hello").use { stream ->
    stream.forEach { chunk -> print(chunk) }
}
// Run finalized with aggregated output on close()
```

## How it works

`TraceProcessIO` gets a new `aggregator` field. When set and `traceable` returns a `Stream`, it instruments the stream via `peek()` (to collect elements) and `onClose()` (to aggregate and record the output). The caller gets back a real `Stream` — no proxy, no type changes. A spliterator wrapper captures iteration errors so the `onClose` handler records the real error instead of attempting aggregation on partial data.

Without an aggregator, `Stream` returns are treated normally — run completes immediately.

## Limitations

- Callers must close the stream (`use {}`/try-with-resources) to finalize the run
- All elements are buffered in memory until close for aggregation
