### PR TITLE
chore: Fix build

### DIFF
--- a/.github/workflows/publish-sonatype.yml
+++ b/.github/workflows/publish-sonatype.yml
@@ -36,8 +36,7 @@ jobs:
           export -- GPG_SIGNING_KEY_ID
           printenv -- GPG_SIGNING_KEY | gpg --batch --passphrase-fd 3 --import 3<<< "$GPG_SIGNING_PASSWORD"
           GPG_SIGNING_KEY_ID="$(gpg --with-colons --list-keys | awk -F : -- '/^pub:/ { getline; print "0x" substr($10, length($10) - 7) }')"
-          # Gradle 9 + Dokka: parallel project execution can trigger "resolution without an exclusive lock"
-          # on dokkaJavadocCollector; --no-parallel avoids that (see gradle/gradle#34473).
+          # Keep publish execution serial to avoid Gradle/Dokka task graph race conditions.
           ./gradlew publishAndReleaseToMavenCentral --stacktrace -PmavenCentralUsername="$SONATYPE_USERNAME" -PmavenCentralPassword="$SONATYPE_PASSWORD" --no-configuration-cache --no-parallel
         env:
           SONATYPE_USERNAME: ${{ secrets.LANGCHAIN_SONATYPE_USERNAME || secrets.SONATYPE_USERNAME }}

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,5 +1,6 @@
 plugins {
     id("org.jetbrains.dokka") version "2.2.0"
+    id("org.jetbrains.dokka-javadoc") version "2.2.0"
 }
 
 repositories {
@@ -22,15 +23,5 @@ subprojects {
         description = "Verifies all source files are formatted."
     }
     apply(plugin = "org.jetbrains.dokka")
-}
-
-subprojects {
-    apply(plugin = "org.jetbrains.dokka")
-}
-
-// Avoid race conditions between `dokkaJavadocCollector` and `dokkaJavadocJar` tasks
-tasks.named("dokkaJavadocCollector").configure {
-    subprojects.flatMap { it.tasks }
-        .filter { it.project.name != "langsmith-java" && it.name == "dokkaJavadocJar" }
-        .forEach { mustRunAfter(it) }
+    apply(plugin = "org.jetbrains.dokka-javadoc")
 }

--- a/buildSrc/src/main/kotlin/langchain.publish.gradle.kts
+++ b/buildSrc/src/main/kotlin/langchain.publish.gradle.kts
@@ -1,6 +1,7 @@
 import com.vanniktech.maven.publish.JavadocJar
 import com.vanniktech.maven.publish.KotlinJvm
 import com.vanniktech.maven.publish.MavenPublishBaseExtension
+import com.vanniktech.maven.publish.SourcesJar
 
 plugins {
     id("com.vanniktech.maven.publish")
@@ -35,8 +36,8 @@ configure<MavenPublishBaseExtension> {
     coordinates(project.group.toString(), project.name, project.version.toString())
     configure(
         KotlinJvm(
-            javadocJar = JavadocJar.Dokka("dokkaJavadoc"),
-            sourcesJar = true,
+            javadocJar = JavadocJar.Dokka("dokkaGeneratePublicationJavadoc"),
+            sourcesJar = SourcesJar.Sources(),
         )
     )
 

--- a/langsmith-java/build.gradle.kts
+++ b/langsmith-java/build.gradle.kts
@@ -7,23 +7,15 @@ dependencies {
     api(project(":langsmith-java-client-okhttp"))
 }
 
-// Redefine `dokkaJavadoc` to:
-// - Depend on the root project's task for merging the docs of all the projects
-// - Forward that task's output to this task's output
-tasks.named("dokkaJavadoc").configure {
-    actions.clear()
-
-    val dokkaJavadocCollector = rootProject.tasks["dokkaJavadocCollector"]
-    dependsOn(dokkaJavadocCollector)
-
-    val outputDirectory = project.layout.buildDirectory.dir("dokka/javadoc")
-    doLast {
-        copy {
-            from(dokkaJavadocCollector.outputs.files)
-            into(outputDirectory)
-            duplicatesStrategy = DuplicatesStrategy.INCLUDE
-        }
-    }
-
-    outputs.dir(outputDirectory)
+// The umbrella `langsmith-java` artifact contains no source of its own, but we still publish a
+// Javadoc JAR containing the docs for the modules it re-exports.
+tasks.named<org.gradle.jvm.tasks.Jar>("dokkaJavadocJar").configure {
+    val reexportedProjects = setOf("langsmith-java-client-okhttp", "langsmith-java-core")
+    val subprojectJavadocTasks =
+        rootProject.subprojects
+            .filter { it.name in reexportedProjects }
+            .map { it.tasks.named("dokkaGeneratePublicationJavadoc") }
+    dependsOn(subprojectJavadocTasks)
+    subprojectJavadocTasks.forEach { from(it) }
+    duplicatesStrategy = DuplicatesStrategy.INCLUDE
 }


### PR DESCRIPTION
Trying to fix our publish action: https://github.com/langchain-ai/langsmith-java/actions/runs/25179482210/job/73820559723

The publish config was still wired to a **Dokka V1 task**:

```kotlin
JavadocJar.Dokka("dokkaJavadoc")
```

But the repo now uses **Dokka 2.2.0**, and Dokka 2 runs in **V2 mode** by default. In V2 mode, the old V1 tasks like:

```text
dokkaJavadoc
dokkaJavadocCollector
dokkaHtml
dokkaHtmlPartial
...
```

still appear in `gradle tasks`, but they are disabled compatibility stubs. If anything tries to execute them, Dokka throws:

```text
Cannot run Dokka V1 tasks when V2 mode is enabled.
Suggestion: Use `dokkaGenerate` or `dokkaGenerateJavadoc` tasks instead.
```

So what broke was not your release credentials or Sonatype. The publish flow got far enough to build/publish artifacts, then Vanniktech tried to build the Javadoc jar by running `:langsmith-java-core:dokkaJavadoc`, and Dokka refused because that is a V1 task.

Why it worked before:
- Either the repo previously used Dokka V1 mode / older Dokka behavior, or
- The publish action previously ran before Dokka V2 mode became active in this branch/base, or
- The local/test paths didn’t exercise publishing Javadoc jars.

The key mismatch was:

```kotlin
// old publish config
JavadocJar.Dokka("dokkaJavadoc") // V1 task
```

with:

```kotlin
// root build
id("org.jetbrains.dokka") version "2.2.0" // V2 mode
```

The fix is to point publishing at the V2-generated Javadoc publication task instead:

```kotlin
JavadocJar.Dokka("dokkaGeneratePublicationJavadoc")
```

and apply the V2 Javadoc format plugin:

```kotlin
id("org.jetbrains.dokka-javadoc") version "2.2.0"
```

The old umbrella `langsmith-java` workaround also depended on `dokkaJavadocCollector`, another V1 task, so that had to be removed/replaced too.