### PR TITLE
Add profile loading

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,15 @@
 .prism.log
 .stdy.log
+.env
+.env.*
+*.pem
+*.key
+*.crt
+credentials.json
+node_modules/
+__pycache__/
+.venv/
+.DS_Store
 .gradle
 .idea
 .kotlin

--- a/langsmith-java-core/src/main/kotlin/com/langchain/smith/core/ClientOptions.kt
+++ b/langsmith-java-core/src/main/kotlin/com/langchain/smith/core/ClientOptions.kt
@@ -111,6 +111,7 @@ private constructor(
     @get:JvmName("autoBatchTracing") val autoBatchTracing: Boolean,
     private val apiKey: String?,
     private val tenantId: String?,
+    private val oauthAccessToken: String?,
 ) {
 
     init {
@@ -172,6 +173,7 @@ private constructor(
         private var autoBatchTracing: Boolean = true
         private var apiKey: String? = null
         private var tenantId: String? = null
+        private var oauthAccessToken: String? = null
 
         @JvmSynthetic
         internal fun from(clientOptions: ClientOptions) = apply {
@@ -190,6 +192,7 @@ private constructor(
             autoBatchTracing = clientOptions.autoBatchTracing
             apiKey = clientOptions.apiKey
             tenantId = clientOptions.tenantId
+            oauthAccessToken = clientOptions.oauthAccessToken
         }
 
         /**
@@ -426,14 +429,9 @@ private constructor(
          * System properties take precedence over environment variables.
          */
         fun fromEnv() = apply {
-            (System.getProperty("langchain.baseUrl") ?: System.getenv("LANGSMITH_ENDPOINT"))?.let {
-                baseUrl(it)
-            }
-            (System.getProperty("langchain.langsmithApiKey") ?: System.getenv("LANGSMITH_API_KEY"))
-                ?.let { apiKey(it) }
-            (System.getProperty("langchain.langsmithTenantId")
-                    ?: System.getenv("LANGSMITH_TENANT_ID"))
-                ?.let { tenantId(it) }
+            langsmithEndpoint()?.let { baseUrl(it) }
+            langsmithApiKey()?.let { apiKey(it) }
+            langsmithTenantId()?.let { tenantId(it) }
             System.getenv("LANGCHAIN_CUSTOM_HEADERS")?.let { customHeadersEnv ->
                 for (line in customHeadersEnv.split("\n")) {
                     val colon = line.indexOf(':')
@@ -442,6 +440,8 @@ private constructor(
                     }
                 }
             }
+            loadProfileClientConfig(jsonMapper, clock, baseUrl, profileNameOverride = profileName())
+                ?.let { applyProfileConfig(it) }
         }
 
         /**
@@ -491,16 +491,26 @@ private constructor(
             // We replace after all the default headers to allow end-users to overwrite them.
             headers.replaceAll(this.headers.build())
             queryParams.replaceAll(this.queryParams.build())
-            apiKey?.let {
-                if (!it.isEmpty()) {
+            apiKey
+                ?.takeIf { it.isNotEmpty() }
+                ?.let {
+                    headers.remove("Authorization")
                     headers.replace("X-API-Key", it)
                 }
+            if (apiKey.isNullOrEmpty()) {
+                oauthAccessToken
+                    ?.takeIf { it.isNotEmpty() }
+                    ?.let {
+                        val currentHeaders = headers.build()
+                        if (
+                            currentHeaders.values("X-API-Key").all(String::isBlank) &&
+                                currentHeaders.values("Authorization").all(String::isBlank)
+                        ) {
+                            headers.replace("Authorization", "Bearer $it")
+                        }
+                    }
             }
-            tenantId?.let {
-                if (!it.isEmpty()) {
-                    headers.replace("X-Tenant-Id", it)
-                }
-            }
+            tenantId?.takeIf { it.isNotEmpty() }?.let { headers.replace("X-Tenant-Id", it) }
 
             return ClientOptions(
                 httpClient,
@@ -524,8 +534,48 @@ private constructor(
                 autoBatchTracing,
                 apiKey,
                 tenantId,
+                oauthAccessToken,
             )
         }
+
+        private fun applyProfileConfig(profile: ProfileClientConfig) {
+            if (baseUrl.isNullOrBlank()) {
+                profile.baseUrl?.let { baseUrl(it) }
+            }
+            if (tenantId.isNullOrBlank()) {
+                profile.tenantId?.let { tenantId(it) }
+            }
+            if (!apiKey.isNullOrBlank() || hasAuthHeader()) {
+                return
+            }
+            if (!profile.oauthAccessToken.isNullOrBlank()) {
+                oauthAccessToken = profile.oauthAccessToken
+            } else if (!profile.apiKey.isNullOrBlank()) {
+                apiKey(profile.apiKey)
+            }
+        }
+
+        private fun hasAuthHeader(): Boolean {
+            val currentHeaders = headers.build()
+            return currentHeaders.values("X-API-Key").any { it.isNotBlank() } ||
+                currentHeaders.values("Authorization").any { it.isNotBlank() }
+        }
+
+        private fun langsmithEndpoint(): String? =
+            System.getProperty("langchain.baseUrl")
+                ?: System.getenv("LANGSMITH_ENDPOINT")
+                ?: System.getenv("LANGCHAIN_ENDPOINT")
+
+        private fun langsmithApiKey(): String? =
+            System.getProperty("langchain.langsmithApiKey")
+                ?: System.getenv("LANGSMITH_API_KEY")
+                ?: System.getenv("LANGCHAIN_API_KEY")
+
+        private fun langsmithTenantId(): String? =
+            System.getProperty("langchain.langsmithTenantId")
+                ?: System.getenv("LANGSMITH_TENANT_ID")
+                ?: System.getenv("LANGSMITH_WORKSPACE_ID")
+                ?: System.getenv("LANGCHAIN_WORKSPACE_ID")
     }
 
     /**

--- a/langsmith-java-core/src/main/kotlin/com/langchain/smith/core/ProfileConfig.kt
+++ b/langsmith-java-core/src/main/kotlin/com/langchain/smith/core/ProfileConfig.kt
@@ -1,0 +1,197 @@
+package com.langchain.smith.core
+
+import com.fasterxml.jackson.databind.JsonNode
+import com.fasterxml.jackson.databind.json.JsonMapper
+import com.fasterxml.jackson.databind.node.ObjectNode
+import java.io.OutputStreamWriter
+import java.net.HttpURLConnection
+import java.net.URL
+import java.net.URLEncoder
+import java.nio.charset.StandardCharsets
+import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.Paths
+import java.time.Clock
+import java.time.Duration
+import java.time.Instant
+import java.time.OffsetDateTime
+
+internal data class ProfileClientConfig(
+    val baseUrl: String?,
+    val apiKey: String?,
+    val tenantId: String?,
+    val oauthAccessToken: String?,
+)
+
+private const val OAUTH_CLIENT_ID = "langsmith-cli"
+private val TOKEN_REFRESH_LEEWAY: Duration = Duration.ofMinutes(1)
+private val TOKEN_REFRESH_TIMEOUT: Duration = Duration.ofSeconds(10)
+
+internal fun loadProfileClientConfig(
+    jsonMapper: JsonMapper,
+    clock: Clock,
+    baseUrlOverride: String?,
+    configPathOverride: Path? = null,
+    profileNameOverride: String? = null,
+): ProfileClientConfig? {
+    val configPath = configPathOverride ?: profileConfigPath()
+    if (!Files.isRegularFile(configPath)) {
+        return null
+    }
+
+    val config =
+        runCatching { jsonMapper.readTree(configPath.toFile()) as? ObjectNode }.getOrNull()
+            ?: return null
+    val profiles = config["profiles"] as? ObjectNode ?: return null
+    val profileName =
+        profileNameOverride?.takeIf { it.isNotBlank() }
+            ?: text(config["current_profile"])
+            ?: "default"
+    val profile = profiles[profileName] as? ObjectNode ?: return null
+
+    refreshProfileOAuthTokenIfNeeded(
+        jsonMapper,
+        clock,
+        configPath,
+        config,
+        profile,
+        baseUrlOverride,
+    )
+
+    val oauth = profile["oauth"]
+    val oauthAccessToken = text(oauth?.get("access_token"))
+
+    return ProfileClientConfig(
+        baseUrl = text(profile["api_url"]),
+        apiKey = text(profile["api_key"]),
+        tenantId = text(profile["workspace_id"]),
+        oauthAccessToken = oauthAccessToken,
+    )
+}
+
+internal fun profileConfigPath(): Path {
+    val configuredPath =
+        System.getProperty("langchain.langsmithConfigFile")
+            ?: System.getenv("LANGSMITH_CONFIG_FILE")
+    return configuredPath?.takeIf { it.isNotBlank() }?.let(Paths::get)
+        ?: Paths.get(System.getProperty("user.home"), ".langsmith", "config.json")
+}
+
+internal fun profileName(): String? =
+    (System.getProperty("langchain.langsmithProfile") ?: System.getenv("LANGSMITH_PROFILE"))
+        ?.takeIf { it.isNotBlank() }
+
+private fun refreshProfileOAuthTokenIfNeeded(
+    jsonMapper: JsonMapper,
+    clock: Clock,
+    configPath: Path,
+    config: ObjectNode,
+    profile: ObjectNode,
+    baseUrlOverride: String?,
+) {
+    val oauth = profile["oauth"] as? ObjectNode ?: return
+    if (!shouldRefreshProfileToken(oauth, clock)) {
+        return
+    }
+    val refreshToken = text(oauth["refresh_token"]) ?: return
+    val tokenEndpointBaseUrl =
+        baseUrlOverride ?: text(profile["api_url"]) ?: ClientOptions.PRODUCTION_URL
+    val tokenResponse =
+        refreshProfileOAuthToken(jsonMapper, tokenEndpointBaseUrl, refreshToken) ?: return
+
+    oauth.put("access_token", tokenResponse.accessToken)
+    tokenResponse.refreshToken?.let { oauth.put("refresh_token", it) }
+    tokenResponse.expiresInSeconds?.let {
+        oauth.put("expires_at", clock.instant().plusSeconds(it).toString())
+    }
+    oauth.remove("token_type")
+    oauth.remove("bearer_token")
+
+    runCatching {
+        configPath.parent?.let { Files.createDirectories(it) }
+        jsonMapper.writerWithDefaultPrettyPrinter().writeValue(configPath.toFile(), config)
+    }
+}
+
+private fun shouldRefreshProfileToken(oauth: ObjectNode, clock: Clock): Boolean {
+    if (text(oauth["refresh_token"]) == null) {
+        return false
+    }
+    if (text(oauth["access_token"]) == null) {
+        return true
+    }
+    val expiresAt = expiresAt(oauth["expires_at"]) ?: return false
+    return !expiresAt.isAfter(clock.instant().plus(TOKEN_REFRESH_LEEWAY))
+}
+
+private fun refreshProfileOAuthToken(
+    jsonMapper: JsonMapper,
+    baseUrl: String,
+    refreshToken: String,
+): OAuthTokenResponse? {
+    return runCatching {
+            val connection =
+                (URL("${normalizeConfigUrl(baseUrl)}/oauth/token").openConnection()
+                        as HttpURLConnection)
+                    .apply {
+                        requestMethod = "POST"
+                        connectTimeout = TOKEN_REFRESH_TIMEOUT.toMillis().toInt()
+                        readTimeout = TOKEN_REFRESH_TIMEOUT.toMillis().toInt()
+                        doOutput = true
+                        setRequestProperty("Content-Type", "application/x-www-form-urlencoded")
+                    }
+            val body =
+                formEncode(
+                    mapOf(
+                        "grant_type" to "refresh_token",
+                        "client_id" to OAUTH_CLIENT_ID,
+                        "refresh_token" to refreshToken,
+                    )
+                )
+            OutputStreamWriter(connection.outputStream, StandardCharsets.UTF_8).use {
+                it.write(body)
+            }
+            if (connection.responseCode !in 200..299) {
+                return@runCatching null
+            }
+            val response = connection.inputStream.use { jsonMapper.readTree(it) }
+            val accessToken = text(response["access_token"]) ?: return@runCatching null
+            OAuthTokenResponse(
+                accessToken = accessToken,
+                refreshToken = text(response["refresh_token"]),
+                expiresInSeconds = response["expires_in"]?.takeIf { it.isNumber }?.asLong(),
+            )
+        }
+        .getOrNull()
+}
+
+private fun normalizeConfigUrl(baseUrl: String): String =
+    baseUrl.trimEnd('/').removeSuffix("/api/v1")
+
+private fun formEncode(values: Map<String, String>): String =
+    values.entries.joinToString("&") { (key, value) -> "${urlEncode(key)}=${urlEncode(value)}" }
+
+private fun urlEncode(value: String): String =
+    URLEncoder.encode(value, StandardCharsets.UTF_8.name())
+
+private fun text(node: JsonNode?): String? =
+    node?.takeIf { it.isTextual }?.asText()?.trimQuotes()?.takeIf { it.isNotBlank() }
+
+private fun expiresAt(node: JsonNode?): Instant? =
+    when {
+        node == null -> null
+        node.isNumber -> Instant.ofEpochSecond(node.asLong())
+        node.isTextual ->
+            runCatching { Instant.parse(node.asText()) }
+                .recoverCatching { OffsetDateTime.parse(node.asText()).toInstant() }
+                .getOrNull()
+        else -> null
+    }
+
+private fun String.trimQuotes(): String = trim().trim('"', '\'')
+
+private data class OAuthTokenResponse(
+    val accessToken: String,
+    val refreshToken: String?,
+    val expiresInSeconds: Long?,
+)

--- a/langsmith-java-core/src/test/kotlin/com/langchain/smith/core/ProfileConfigTest.kt
+++ b/langsmith-java-core/src/test/kotlin/com/langchain/smith/core/ProfileConfigTest.kt
@@ -1,0 +1,162 @@
+package com.langchain.smith.core
+
+import com.sun.net.httpserver.HttpServer
+import java.net.InetSocketAddress
+import java.nio.charset.StandardCharsets
+import java.nio.file.Files
+import java.nio.file.Path
+import java.time.Clock
+import java.time.Instant
+import java.time.ZoneOffset
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+
+internal class ProfileConfigTest {
+
+    @TempDir lateinit var tempDir: Path
+
+    private val clock = Clock.fixed(Instant.parse("2026-01-01T00:00:00Z"), ZoneOffset.UTC)
+
+    @Test
+    fun loadProfileClientConfigUsesCurrentProfile() {
+        val configPath =
+            writeConfig(
+                """
+                {
+                  "current_profile": "dev",
+                  "profiles": {
+                    "default": {
+                      "api_url": "https://default.example.com",
+                      "api_key": "default-key"
+                    },
+                    "dev": {
+                      "api_url": "https://dev.example.com",
+                      "api_key": "dev-key",
+                      "workspace_id": "workspace-id"
+                    }
+                  }
+                }
+                """
+                    .trimIndent()
+            )
+
+        val config =
+            loadProfileClientConfig(
+                jsonMapper = jsonMapper(),
+                clock = clock,
+                baseUrlOverride = null,
+                configPathOverride = configPath,
+            )
+
+        assertThat(config?.baseUrl).isEqualTo("https://dev.example.com")
+        assertThat(config?.apiKey).isEqualTo("dev-key")
+        assertThat(config?.tenantId).isEqualTo("workspace-id")
+    }
+
+    @Test
+    fun loadProfileClientConfigPrefersOauthAccessToken() {
+        val configPath =
+            writeConfig(
+                """
+                {
+                  "profiles": {
+                    "default": {
+                      "api_url": "https://profile.example.com",
+                      "api_key": "profile-key",
+                      "oauth": {
+                        "access_token": "profile-access-token"
+                      }
+                    }
+                  }
+                }
+                """
+                    .trimIndent()
+            )
+
+        val config =
+            loadProfileClientConfig(
+                jsonMapper = jsonMapper(),
+                clock = clock,
+                baseUrlOverride = null,
+                configPathOverride = configPath,
+            )
+
+        assertThat(config?.oauthAccessToken).isEqualTo("profile-access-token")
+        assertThat(config?.apiKey).isEqualTo("profile-key")
+    }
+
+    @Test
+    fun loadProfileClientConfigRefreshesExpiredOauthToken() {
+        val server = HttpServer.create(InetSocketAddress("127.0.0.1", 0), 0)
+        var requestBody = ""
+        server.createContext("/oauth/token") { exchange ->
+            requestBody =
+                exchange.requestBody.bufferedReader(StandardCharsets.UTF_8).use { it.readText() }
+            val response =
+                """
+                {
+                  "access_token": "new-access-token",
+                  "refresh_token": "new-refresh-token",
+                  "expires_in": 3600,
+                  "token_type": "Bearer",
+                  "bearer_token": "ignored"
+                }
+                """
+                    .trimIndent()
+                    .toByteArray(StandardCharsets.UTF_8)
+            exchange.responseHeaders.add("Content-Type", "application/json")
+            exchange.sendResponseHeaders(200, response.size.toLong())
+            exchange.responseBody.use { it.write(response) }
+        }
+        server.start()
+        try {
+            val port = server.address.port
+            val configPath =
+                writeConfig(
+                    """
+                    {
+                      "profiles": {
+                        "default": {
+                          "api_url": "http://127.0.0.1:$port/api/v1/",
+                          "oauth": {
+                            "access_token": "old-access-token",
+                            "refresh_token": "old-refresh-token",
+                            "expires_at": "2000-01-01T00:00:00Z",
+                            "token_type": "Bearer",
+                            "bearer_token": "old-bearer-token"
+                          }
+                        }
+                      }
+                    }
+                    """
+                        .trimIndent()
+                )
+
+            val config =
+                loadProfileClientConfig(
+                    jsonMapper = jsonMapper(),
+                    clock = clock,
+                    baseUrlOverride = null,
+                    configPathOverride = configPath,
+                )
+
+            val updatedConfig = String(Files.readAllBytes(configPath), StandardCharsets.UTF_8)
+            assertThat(config?.oauthAccessToken).isEqualTo("new-access-token")
+            assertThat(requestBody).contains("grant_type=refresh_token")
+            assertThat(requestBody).contains("client_id=langsmith-cli")
+            assertThat(requestBody).contains("refresh_token=old-refresh-token")
+            assertThat(updatedConfig).contains("new-refresh-token")
+            assertThat(updatedConfig).doesNotContain("token_type")
+            assertThat(updatedConfig).doesNotContain("bearer_token")
+        } finally {
+            server.stop(0)
+        }
+    }
+
+    private fun writeConfig(contents: String): Path {
+        val configPath = tempDir.resolve("config.json")
+        Files.write(configPath, contents.toByteArray(StandardCharsets.UTF_8))
+        return configPath
+    }
+}


### PR DESCRIPTION
Adds LangSmith profile loading to Java client configuration, matching the JS/Python/Go behavior.\n\n- Loads profiles from LANGSMITH_CONFIG_FILE or ~/.langsmith/config.json when using fromEnv()\n- Selects LANGSMITH_PROFILE, current_profile, then default\n- Applies profile api_url, api_key, workspace_id, and OAuth bearer auth when env/explicit auth is absent\n- Refreshes expired OAuth profile tokens and persists refreshed token fields\n\nLocal verification:\n- git diff --check\n- Not run: Gradle formatter/tests, because this environment has no usable Java runtime configured (java -version reports no runtime).