### PR TITLE
Refresh profile auth before requests

### DIFF
--- a/langsmith-java-core/src/main/kotlin/com/langchain/smith/core/ClientOptions.kt
+++ b/langsmith-java-core/src/main/kotlin/com/langchain/smith/core/ClientOptions.kt
@@ -112,6 +112,7 @@ private constructor(
     private val apiKey: String?,
     private val tenantId: String?,
     private val oauthAccessToken: String?,
+    private val profileAuth: ProfileAuth?,
 ) {
 
     init {
@@ -174,6 +175,7 @@ private constructor(
         private var apiKey: String? = null
         private var tenantId: String? = null
         private var oauthAccessToken: String? = null
+        private var profileAuth: ProfileAuth? = null
 
         @JvmSynthetic
         internal fun from(clientOptions: ClientOptions) = apply {
@@ -193,6 +195,7 @@ private constructor(
             apiKey = clientOptions.apiKey
             tenantId = clientOptions.tenantId
             oauthAccessToken = clientOptions.oauthAccessToken
+            profileAuth = clientOptions.profileAuth
         }
 
         /**
@@ -440,8 +443,9 @@ private constructor(
                     }
                 }
             }
-            loadProfileClientConfig(jsonMapper, clock, baseUrl, profileNameOverride = profileName())
-                ?.let { applyProfileConfig(it) }
+            loadProfileClientConfig(jsonMapper, clock, profileNameOverride = profileName())?.let {
+                applyProfileConfig(it)
+            }
         }
 
         /**
@@ -512,14 +516,18 @@ private constructor(
             }
             tenantId?.takeIf { it.isNotEmpty() }?.let { headers.replace("X-Tenant-Id", it) }
 
-            return ClientOptions(
-                httpClient,
+            val retryingHttpClient =
                 RetryingHttpClient.builder()
                     .httpClient(httpClient)
                     .sleeper(sleeper)
                     .clock(clock)
                     .maxRetries(maxRetries)
-                    .build(),
+                    .build()
+
+            return ClientOptions(
+                httpClient,
+                profileAuth?.let { ProfileAuthHttpClient(retryingHttpClient, it) }
+                    ?: retryingHttpClient,
                 checkJacksonVersionCompatibility,
                 jsonMapper,
                 streamHandlerExecutor,
@@ -535,6 +543,7 @@ private constructor(
                 apiKey,
                 tenantId,
                 oauthAccessToken,
+                profileAuth,
             )
         }
 
@@ -550,6 +559,9 @@ private constructor(
             }
             if (!profile.oauthAccessToken.isNullOrBlank()) {
                 oauthAccessToken = profile.oauthAccessToken
+                profileAuth = profile.profileAuth
+            } else if (profile.profileAuth != null) {
+                profileAuth = profile.profileAuth
             } else if (!profile.apiKey.isNullOrBlank()) {
                 apiKey(profile.apiKey)
             }

--- a/langsmith-java-core/src/main/kotlin/com/langchain/smith/core/ProfileConfig.kt
+++ b/langsmith-java-core/src/main/kotlin/com/langchain/smith/core/ProfileConfig.kt
@@ -3,6 +3,9 @@ package com.langchain.smith.core
 import com.fasterxml.jackson.databind.JsonNode
 import com.fasterxml.jackson.databind.json.JsonMapper
 import com.fasterxml.jackson.databind.node.ObjectNode
+import com.langchain.smith.core.http.HttpClient
+import com.langchain.smith.core.http.HttpRequest
+import com.langchain.smith.core.http.HttpResponse
 import java.io.OutputStreamWriter
 import java.net.HttpURLConnection
 import java.net.URL
@@ -15,12 +18,14 @@ import java.time.Clock
 import java.time.Duration
 import java.time.Instant
 import java.time.OffsetDateTime
+import java.util.concurrent.CompletableFuture
 
 internal data class ProfileClientConfig(
     val baseUrl: String?,
     val apiKey: String?,
     val tenantId: String?,
     val oauthAccessToken: String?,
+    val profileAuth: ProfileAuth?,
 )
 
 private const val OAUTH_CLIENT_ID = "langsmith-cli"
@@ -30,7 +35,6 @@ private val TOKEN_REFRESH_TIMEOUT: Duration = Duration.ofSeconds(10)
 internal fun loadProfileClientConfig(
     jsonMapper: JsonMapper,
     clock: Clock,
-    baseUrlOverride: String?,
     configPathOverride: Path? = null,
     profileNameOverride: String? = null,
 ): ProfileClientConfig? {
@@ -49,23 +53,21 @@ internal fun loadProfileClientConfig(
             ?: "default"
     val profile = profiles[profileName] as? ObjectNode ?: return null
 
-    refreshProfileOAuthTokenIfNeeded(
-        jsonMapper,
-        clock,
-        configPath,
-        config,
-        profile,
-        baseUrlOverride,
-    )
-
     val oauth = profile["oauth"]
     val oauthAccessToken = text(oauth?.get("access_token"))
+    val oauthRefreshToken = text(oauth?.get("refresh_token"))
 
     return ProfileClientConfig(
         baseUrl = text(profile["api_url"]),
         apiKey = text(profile["api_key"]),
         tenantId = text(profile["workspace_id"]),
         oauthAccessToken = oauthAccessToken,
+        profileAuth =
+            if (oauthAccessToken != null || oauthRefreshToken != null) {
+                ProfileAuth(jsonMapper, clock, configPath, config, profile)
+            } else {
+                null
+            },
     )
 }
 
@@ -80,38 +82,6 @@ internal fun profileConfigPath(): Path {
 internal fun profileName(): String? =
     (System.getProperty("langchain.langsmithProfile") ?: System.getenv("LANGSMITH_PROFILE"))
         ?.takeIf { it.isNotBlank() }
-
-private fun refreshProfileOAuthTokenIfNeeded(
-    jsonMapper: JsonMapper,
-    clock: Clock,
-    configPath: Path,
-    config: ObjectNode,
-    profile: ObjectNode,
-    baseUrlOverride: String?,
-) {
-    val oauth = profile["oauth"] as? ObjectNode ?: return
-    if (!shouldRefreshProfileToken(oauth, clock)) {
-        return
-    }
-    val refreshToken = text(oauth["refresh_token"]) ?: return
-    val tokenEndpointBaseUrl =
-        baseUrlOverride ?: text(profile["api_url"]) ?: ClientOptions.PRODUCTION_URL
-    val tokenResponse =
-        refreshProfileOAuthToken(jsonMapper, tokenEndpointBaseUrl, refreshToken) ?: return
-
-    oauth.put("access_token", tokenResponse.accessToken)
-    tokenResponse.refreshToken?.let { oauth.put("refresh_token", it) }
-    tokenResponse.expiresInSeconds?.let {
-        oauth.put("expires_at", clock.instant().plusSeconds(it).toString())
-    }
-    oauth.remove("token_type")
-    oauth.remove("bearer_token")
-
-    runCatching {
-        configPath.parent?.let { Files.createDirectories(it) }
-        jsonMapper.writerWithDefaultPrettyPrinter().writeValue(configPath.toFile(), config)
-    }
-}
 
 private fun shouldRefreshProfileToken(oauth: ObjectNode, clock: Clock): Boolean {
     if (text(oauth["refresh_token"]) == null) {
@@ -189,6 +159,112 @@ private fun expiresAt(node: JsonNode?): Instant? =
     }
 
 private fun String.trimQuotes(): String = trim().trim('"', '\'')
+
+internal class ProfileAuth(
+    private val jsonMapper: JsonMapper,
+    private val clock: Clock,
+    private val configPath: Path,
+    private val config: ObjectNode,
+    private val profile: ObjectNode,
+) {
+    private val managedAuthorizationValues = mutableSetOf<String>()
+
+    init {
+        rememberProfileAuthHeader(authHeaderFromProfile())
+    }
+
+    @Synchronized
+    fun currentAuthHeader(): Pair<String, String>? =
+        authHeaderFromProfile().also { rememberProfileAuthHeader(it) }
+
+    @Synchronized
+    fun isProfileAuthorizationHeader(value: String): Boolean =
+        managedAuthorizationValues.contains(value)
+
+    @Synchronized
+    fun authHeader(baseUrlOverride: String?): Pair<String, String>? {
+        val oauth = profile["oauth"] as? ObjectNode
+        if (oauth != null && shouldRefreshProfileToken(oauth, clock)) {
+            val refreshToken = text(oauth["refresh_token"])
+            if (refreshToken != null) {
+                val tokenEndpointBaseUrl =
+                    baseUrlOverride ?: text(profile["api_url"]) ?: ClientOptions.PRODUCTION_URL
+                val tokenResponse =
+                    refreshProfileOAuthToken(jsonMapper, tokenEndpointBaseUrl, refreshToken)
+                if (tokenResponse != null) {
+                    oauth.put("access_token", tokenResponse.accessToken)
+                    tokenResponse.refreshToken?.let { oauth.put("refresh_token", it) }
+                    tokenResponse.expiresInSeconds?.let {
+                        oauth.put("expires_at", clock.instant().plusSeconds(it).toString())
+                    }
+                    oauth.remove("token_type")
+                    oauth.remove("bearer_token")
+                    saveConfig()
+                }
+            }
+        }
+        return authHeaderFromProfile().also { rememberProfileAuthHeader(it) }
+    }
+
+    private fun authHeaderFromProfile(): Pair<String, String>? {
+        val oauth = profile["oauth"] as? ObjectNode
+        text(oauth?.get("access_token"))?.let {
+            return "Authorization" to "Bearer $it"
+        }
+        text(profile["api_key"])?.let {
+            return "X-API-Key" to it
+        }
+        return null
+    }
+
+    private fun rememberProfileAuthHeader(header: Pair<String, String>?) {
+        if (header?.first?.equals("Authorization", ignoreCase = true) == true) {
+            managedAuthorizationValues.add(header.second)
+        }
+    }
+
+    private fun saveConfig() {
+        runCatching {
+            configPath.parent?.let { Files.createDirectories(it) }
+            jsonMapper.writerWithDefaultPrettyPrinter().writeValue(configPath.toFile(), config)
+        }
+    }
+}
+
+internal class ProfileAuthHttpClient(
+    private val delegate: HttpClient,
+    private val profileAuth: ProfileAuth,
+) : HttpClient {
+    override fun execute(request: HttpRequest, requestOptions: RequestOptions): HttpResponse =
+        delegate.execute(prepareProfileAuthRequest(request), requestOptions)
+
+    override fun executeAsync(
+        request: HttpRequest,
+        requestOptions: RequestOptions,
+    ): CompletableFuture<HttpResponse> =
+        delegate.executeAsync(prepareProfileAuthRequest(request), requestOptions)
+
+    override fun close() = delegate.close()
+
+    private fun prepareProfileAuthRequest(request: HttpRequest): HttpRequest {
+        if (request.headers.values("X-API-Key").any(String::isNotBlank)) {
+            return request.toBuilder().removeHeaders("Authorization").build()
+        }
+        val authorizationValues = request.headers.values("Authorization").filter(String::isNotBlank)
+        if (
+            authorizationValues.isNotEmpty() &&
+                authorizationValues.none { profileAuth.isProfileAuthorizationHeader(it) }
+        ) {
+            return request
+        }
+        val (name, value) = profileAuth.authHeader(request.baseUrl) ?: return request
+        val builder = request.toBuilder()
+        if (name.equals("X-API-Key", ignoreCase = true)) {
+            builder.removeHeaders("Authorization")
+        }
+        return builder.replaceHeaders(name, value).build()
+    }
+}
 
 private data class OAuthTokenResponse(
     val accessToken: String,

--- a/langsmith-java-core/src/main/kotlin/com/langchain/smith/core/ProfileConfig.kt
+++ b/langsmith-java-core/src/main/kotlin/com/langchain/smith/core/ProfileConfig.kt
@@ -182,13 +182,12 @@ internal class ProfileAuth(
         managedAuthorizationValues.contains(value)
 
     @Synchronized
-    fun authHeader(baseUrlOverride: String?): Pair<String, String>? {
+    fun authHeader(): Pair<String, String>? {
         val oauth = profile["oauth"] as? ObjectNode
         if (oauth != null && shouldRefreshProfileToken(oauth, clock)) {
             val refreshToken = text(oauth["refresh_token"])
             if (refreshToken != null) {
-                val tokenEndpointBaseUrl =
-                    baseUrlOverride ?: text(profile["api_url"]) ?: ClientOptions.PRODUCTION_URL
+                val tokenEndpointBaseUrl = text(profile["api_url"]) ?: ClientOptions.PRODUCTION_URL
                 val tokenResponse =
                     refreshProfileOAuthToken(jsonMapper, tokenEndpointBaseUrl, refreshToken)
                 if (tokenResponse != null) {
@@ -257,7 +256,7 @@ internal class ProfileAuthHttpClient(
         ) {
             return request
         }
-        val (name, value) = profileAuth.authHeader(request.baseUrl) ?: return request
+        val (name, value) = profileAuth.authHeader() ?: return request
         val builder = request.toBuilder()
         if (name.equals("X-API-Key", ignoreCase = true)) {
             builder.removeHeaders("Authorization")

--- a/langsmith-java-core/src/test/kotlin/com/langchain/smith/core/ProfileConfigTest.kt
+++ b/langsmith-java-core/src/test/kotlin/com/langchain/smith/core/ProfileConfigTest.kt
@@ -1,6 +1,13 @@
 package com.langchain.smith.core
 
+import com.langchain.smith.core.http.Headers
+import com.langchain.smith.core.http.HttpClient
+import com.langchain.smith.core.http.HttpMethod
+import com.langchain.smith.core.http.HttpRequest
+import com.langchain.smith.core.http.HttpResponse
 import com.sun.net.httpserver.HttpServer
+import java.io.ByteArrayInputStream
+import java.io.InputStream
 import java.net.InetSocketAddress
 import java.nio.charset.StandardCharsets
 import java.nio.file.Files
@@ -8,6 +15,7 @@ import java.nio.file.Path
 import java.time.Clock
 import java.time.Instant
 import java.time.ZoneOffset
+import java.util.concurrent.CompletableFuture
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.io.TempDir
@@ -45,7 +53,6 @@ internal class ProfileConfigTest {
             loadProfileClientConfig(
                 jsonMapper = jsonMapper(),
                 clock = clock,
-                baseUrlOverride = null,
                 configPathOverride = configPath,
             )
 
@@ -78,7 +85,6 @@ internal class ProfileConfigTest {
             loadProfileClientConfig(
                 jsonMapper = jsonMapper(),
                 clock = clock,
-                baseUrlOverride = null,
                 configPathOverride = configPath,
             )
 
@@ -87,7 +93,7 @@ internal class ProfileConfigTest {
     }
 
     @Test
-    fun loadProfileClientConfigRefreshesExpiredOauthToken() {
+    fun profileAuthRefreshesExpiredOauthTokenBeforeRequest() {
         val server = HttpServer.create(InetSocketAddress("127.0.0.1", 0), 0)
         var requestBody = ""
         server.createContext("/oauth/token") { exchange ->
@@ -137,22 +143,74 @@ internal class ProfileConfigTest {
                 loadProfileClientConfig(
                     jsonMapper = jsonMapper(),
                     clock = clock,
-                    baseUrlOverride = null,
                     configPathOverride = configPath,
                 )
 
-            val updatedConfig = String(Files.readAllBytes(configPath), StandardCharsets.UTF_8)
-            assertThat(config?.oauthAccessToken).isEqualTo("new-access-token")
+            assertThat(config?.oauthAccessToken).isEqualTo("old-access-token")
+            assertThat(requestBody).isEmpty()
+
+            val authHeader = config?.profileAuth?.authHeader("http://127.0.0.1:$port/api/v1/")
+
+            assertThat(authHeader).isEqualTo("Authorization" to "Bearer new-access-token")
             assertThat(requestBody).contains("grant_type=refresh_token")
             assertThat(requestBody).contains("client_id=langsmith-cli")
             assertThat(requestBody).contains("refresh_token=old-refresh-token")
-            assertThat(updatedConfig).contains("new-refresh-token")
-            assertThat(updatedConfig).doesNotContain("token_type")
-            assertThat(updatedConfig).doesNotContain("bearer_token")
+            val refreshedConfig = String(Files.readAllBytes(configPath), StandardCharsets.UTF_8)
+            assertThat(refreshedConfig).contains("new-refresh-token")
+            assertThat(refreshedConfig).doesNotContain("token_type")
+            assertThat(refreshedConfig).doesNotContain("bearer_token")
+
+            val capturedAuthHeaders = mutableListOf<String?>()
+            val profileHttpClient =
+                ProfileAuthHttpClient(
+                    object : HttpClient {
+                        override fun execute(
+                            request: HttpRequest,
+                            requestOptions: RequestOptions,
+                        ): HttpResponse {
+                            capturedAuthHeaders.add(
+                                request.headers.values("Authorization").firstOrNull()
+                            )
+                            return emptyResponse()
+                        }
+
+                        override fun executeAsync(
+                            request: HttpRequest,
+                            requestOptions: RequestOptions,
+                        ): CompletableFuture<HttpResponse> =
+                            CompletableFuture.completedFuture(execute(request, requestOptions))
+
+                        override fun close() {}
+                    },
+                    config!!.profileAuth!!,
+                )
+            val staleProfileRequest =
+                HttpRequest.builder()
+                    .method(HttpMethod.GET)
+                    .baseUrl("http://127.0.0.1:$port/api/v1/")
+                    .replaceHeaders("Authorization", "Bearer old-access-token")
+                    .build()
+
+            profileHttpClient.execute(staleProfileRequest).close()
+            profileHttpClient.execute(staleProfileRequest).close()
+
+            assertThat(capturedAuthHeaders)
+                .containsExactly("Bearer new-access-token", "Bearer new-access-token")
         } finally {
             server.stop(0)
         }
     }
+
+    private fun emptyResponse(): HttpResponse =
+        object : HttpResponse {
+            override fun statusCode(): Int = 200
+
+            override fun headers(): Headers = Headers.builder().build()
+
+            override fun body(): InputStream = ByteArrayInputStream(ByteArray(0))
+
+            override fun close() {}
+        }
 
     private fun writeConfig(contents: String): Path {
         val configPath = tempDir.resolve("config.json")

--- a/langsmith-java-core/src/test/kotlin/com/langchain/smith/core/ProfileConfigTest.kt
+++ b/langsmith-java-core/src/test/kotlin/com/langchain/smith/core/ProfileConfigTest.kt
@@ -149,7 +149,7 @@ internal class ProfileConfigTest {
             assertThat(config?.oauthAccessToken).isEqualTo("old-access-token")
             assertThat(requestBody).isEmpty()
 
-            val authHeader = config?.profileAuth?.authHeader("http://127.0.0.1:$port/api/v1/")
+            val authHeader = config?.profileAuth?.authHeader()
 
             assertThat(authHeader).isEqualTo("Authorization" to "Bearer new-access-token")
             assertThat(requestBody).contains("grant_type=refresh_token")


### PR DESCRIPTION
## Summary

Adds request-time LangSmith profile OAuth refresh to the Java SDK, based on `next`.

- Keeps `ClientOptions.fromEnv()` profile loading side-effect free
- Wraps the HTTP client with profile auth refresh before requests
- Refreshes expired OAuth profile tokens and writes refreshed token fields back to the profile file
- Uses the selected profile's `api_url` for OAuth refresh, even when request/client base URL is overridden
- Preserves explicit request `Authorization` headers while replacing stale profile-managed bearer headers
- Exposes both OAuth access and refresh tokens in the loaded profile client config

## Auth precedence

Explicit/env API-key auth suppresses profile auth. When profile auth is used, OAuth access tokens are preferred over profile `api_key`; a profile `api_key` remains a fallback if OAuth cannot provide an access token.

## Verification

- `./gradlew :langsmith-java-core:formatKotlin`
- `./gradlew :langsmith-java-core:lintKotlin :langsmith-java-core:test --tests com.langchain.smith.core.ProfileConfigTest`
