### PR TITLE
Expose profile OAuth refresh token

### DIFF
--- a/langsmith-java-core/src/main/kotlin/com/langchain/smith/core/ProfileConfig.kt
+++ b/langsmith-java-core/src/main/kotlin/com/langchain/smith/core/ProfileConfig.kt
@@ -25,6 +25,7 @@ internal data class ProfileClientConfig(
     val apiKey: String?,
     val tenantId: String?,
     val oauthAccessToken: String?,
+    val oauthRefreshToken: String?,
     val profileAuth: ProfileAuth?,
 )
 
@@ -62,6 +63,7 @@ internal fun loadProfileClientConfig(
         apiKey = text(profile["api_key"]),
         tenantId = text(profile["workspace_id"]),
         oauthAccessToken = oauthAccessToken,
+        oauthRefreshToken = oauthRefreshToken,
         profileAuth =
             if (oauthAccessToken != null || oauthRefreshToken != null) {
                 ProfileAuth(jsonMapper, clock, configPath, config, profile)

--- a/langsmith-java-core/src/test/kotlin/com/langchain/smith/core/ProfileConfigTest.kt
+++ b/langsmith-java-core/src/test/kotlin/com/langchain/smith/core/ProfileConfigTest.kt
@@ -147,6 +147,7 @@ internal class ProfileConfigTest {
                 )
 
             assertThat(config?.oauthAccessToken).isEqualTo("old-access-token")
+            assertThat(config?.oauthRefreshToken).isEqualTo("old-refresh-token")
             assertThat(requestBody).isEmpty()
 
             val authHeader = config?.profileAuth?.authHeader()


### PR DESCRIPTION
## Summary

Adds the OAuth refresh token to Java's loaded profile client config.

- Exposes `oauthRefreshToken` next to `oauthAccessToken` in `ProfileClientConfig`
- Keeps the existing `ProfileAuth` request-time refresh service unchanged
- Adds test coverage that the refresh token is loaded from the profile config

## Verification

- `./gradlew :langsmith-java-core:formatKotlin :langsmith-java-core:lintKotlin :langsmith-java-core:test --tests com.langchain.smith.core.ProfileConfigTest`
