### PR TITLE
feat(sandbox): make snapshot optional

### DIFF
--- a/langsmith-java-core/src/main/kotlin/com/langchain/smith/models/sandboxes/boxes/BoxCreateParams.kt
+++ b/langsmith-java-core/src/main/kotlin/com/langchain/smith/models/sandboxes/boxes/BoxCreateParams.kt
@@ -12,6 +12,7 @@ import com.langchain.smith.core.JsonField
 import com.langchain.smith.core.JsonMissing
 import com.langchain.smith.core.JsonValue
 import com.langchain.smith.core.Params
+import com.langchain.smith.core.checkKnown
 import com.langchain.smith.core.checkRequired
 import com.langchain.smith.core.http.Headers
 import com.langchain.smith.core.http.QueryParams

--- a/langsmith-java-core/src/main/kotlin/com/langchain/smith/models/sandboxes/boxes/BoxCreateParams.kt
+++ b/langsmith-java-core/src/main/kotlin/com/langchain/smith/models/sandboxes/boxes/BoxCreateParams.kt
@@ -12,7 +12,6 @@ import com.langchain.smith.core.JsonField
 import com.langchain.smith.core.JsonMissing
 import com.langchain.smith.core.JsonValue
 import com.langchain.smith.core.Params
-import com.langchain.smith.core.checkKnown
 import com.langchain.smith.core.checkRequired
 import com.langchain.smith.core.http.Headers
 import com.langchain.smith.core.http.QueryParams
@@ -24,8 +23,8 @@ import java.util.Optional
 import kotlin.jvm.optionals.getOrNull
 
 /**
- * Create a new sandbox from a snapshot. The snapshot may be identified by `snapshot_id` (UUID) or
- * by `snapshot_name` (tenant-scoped unique name); exactly one must be set.
+ * Create a new sandbox using server defaults. Set `snapshot_id` or `snapshot_name` only when
+ * booting from a reusable snapshot.
  */
 class BoxCreateParams
 private constructor(

--- a/langsmith-java-core/src/main/kotlin/com/langchain/smith/services/async/sandboxes/BoxServiceAsync.kt
+++ b/langsmith-java-core/src/main/kotlin/com/langchain/smith/services/async/sandboxes/BoxServiceAsync.kt
@@ -42,8 +42,8 @@ interface BoxServiceAsync {
     fun withOptions(modifier: Consumer<ClientOptions.Builder>): BoxServiceAsync
 
     /**
-     * Create a new sandbox from a snapshot. The snapshot may be identified by `snapshot_id` (UUID)
-     * or by `snapshot_name` (tenant-scoped unique name); exactly one must be set.
+     * Create a new sandbox using server defaults. Set `snapshot_id` or `snapshot_name` only when
+     * booting from a reusable snapshot.
      */
     fun create(): CompletableFuture<BoxCreateResponse> = create(BoxCreateParams.none())
 

--- a/langsmith-java-core/src/main/kotlin/com/langchain/smith/services/blocking/sandboxes/BoxService.kt
+++ b/langsmith-java-core/src/main/kotlin/com/langchain/smith/services/blocking/sandboxes/BoxService.kt
@@ -42,8 +42,8 @@ interface BoxService {
     fun withOptions(modifier: Consumer<ClientOptions.Builder>): BoxService
 
     /**
-     * Create a new sandbox from a snapshot. The snapshot may be identified by `snapshot_id` (UUID)
-     * or by `snapshot_name` (tenant-scoped unique name); exactly one must be set.
+     * Create a new sandbox using server defaults. Set `snapshot_id` or `snapshot_name` only when
+     * booting from a reusable snapshot.
      */
     fun create(): BoxCreateResponse = create(BoxCreateParams.none())
 

--- a/langsmith-java-core/src/test/kotlin/com/langchain/smith/models/sandboxes/boxes/BoxCreateParamsTest.kt
+++ b/langsmith-java-core/src/test/kotlin/com/langchain/smith/models/sandboxes/boxes/BoxCreateParamsTest.kt
@@ -190,5 +190,8 @@ internal class BoxCreateParamsTest {
         val params = BoxCreateParams.builder().build()
 
         val body = params._body()
+
+        assertThat(body.snapshotId()).isEmpty()
+        assertThat(body.snapshotName()).isEmpty()
     }
 }


### PR DESCRIPTION
## Summary

Update sandbox create params and service docs so omitting snapshot_id/snapshot_name means using the server default runtime.

## Test Plan

- [x] ./gradlew :langsmith-java-core:test --tests com.langchain.smith.models.sandboxes.boxes.BoxCreateParamsTest (blocked locally: JDK 21 toolchain not installed/configured)