### PR TITLE
fix: patch security alerts — OTel, Tomcat, Jetty, Logback, Spring, SnakeYAML

### DIFF
--- a/SECURITY_FIX_PLAN.md
+++ b/SECURITY_FIX_PLAN.md
@@ -1,0 +1,57 @@
+# Security Fix Plan — langsmith-java
+
+Validated 2026-05-20 against open Dependabot alerts.
+
+## Status
+
+| Item | Priority | Scope | Status |
+|------|----------|-------|--------|
+| OpenTelemetry 1.32.0 → 1.62.0 | P1 | **Published** (affects end users) | ✅ Done |
+| Tomcat 9.0.115 → 9.0.118 | P2 | Example module only (non-published) | ✅ Done |
+| Jetty 9.4.57 → 9.4.58 (http2, server) | P3 | Test scope only | ✅ Done |
+| Logback 1.2.13 → 1.5.32 | P4 | Test + example scope (non-published) | ✅ Done |
+| Spring 5.3.34 → 5.3.39 | P5 | Example module only (non-published) | ✅ Done |
+| SnakeYAML 1.31 → 1.32 | P6 | Example module only (non-published) | ✅ Done |
+| Spring Boot 3.x upgrade (example) | Upstream | Removes 17 no-fix-available alerts | ⏳ Future |
+
+## Alerts Already Fixed (Stale — Can Be Dismissed)
+
+These 15 alerts show as open but the code already addresses them via explicit constraints:
+
+| Alert # | CVE | Package | Fixed By |
+|---------|-----|---------|----------|
+| #50 | CVE-2024-13009 | jetty-server | `require("9.4.57.v20241219")` |
+| #39 | CVE-2024-8184 | jetty-server | `require("9.4.57.v20241219")` |
+| #28 | CVE-2023-44487 | http2-server | sibling of constrained http2-common |
+| #27 | CVE-2023-44487 | http2-common | `require("9.4.57.v20241219")` |
+| #25 | CVE-2024-22201 | http2-common | `require("9.4.57.v20241219")` |
+| #17 | CVE-2023-36478 | http2-hpack | `require("9.4.57.v20241219")` |
+| #13 | CVE-2023-26049 | jetty-server | `require("9.4.57.v20241219")` |
+| #12 | CVE-2023-26048 | jetty-server | `require("9.4.57.v20241219")` |
+| #62 | CVE-2025-48976 | commons-fileupload | `require("1.6.0")` |
+| #10 | CVE-2023-24998 | commons-fileupload | `require("1.6.0")` |
+| #38 | CVE-2024-47554 | commons-io | `require("2.14.0")` |
+| #11 | CVE-2023-1370 | json-smart | `require("2.4.9")` |
+| #61 | CVE-2025-52999 | jackson-core | published at 2.18.6 |
+| #75 | GHSA-72hv-8253-57qq | jackson-core | published at 2.18.6 (patched version) |
+| #76 | GHSA-72hv-8253-57qq | jackson-core | 2.18.6 not in vulnerable range (≥2.19 only) |
+
+## No Fix Available (Upstream — Spring 5.x Limitations)
+
+These require either a Spring Boot 3.x upgrade or a Jetty major version upgrade.
+They live entirely in the non-published `langsmith-java-example` module.
+
+| Alert #s | CVEs | Package | Reason |
+|---------|------|---------|--------|
+| #7 | CVE-2016-1000027 | spring-web | Requires spring-web 6.0 (Spring Boot 3.x) |
+| #42, #53 | CVE-2024-38816, CVE-2024-38819 | spring-webmvc | No fix in Spring 5.x |
+| #49, #104 | CVE-2025-22235, CVE-2026-40973 | spring-boot | No fix available |
+| #55, #56 | CVE-2024-38820 | spring-web/context | No fix available |
+| #57 | CVE-2025-22233 | spring-context | No fix available |
+| #64 | CVE-2025-41242 | spring-webmvc | No fix in Spring 5.x |
+| #67 | CVE-2025-41249 | spring-core | No fix in Spring 5.x |
+| #83, #84 | CVE-2026-22735, CVE-2026-22737 | spring-webmvc | No fix in Spring 5.x |
+| #99 | CVE-2026-2332 | jetty-http | No 9.x fix |
+| #105, #106 | CVE-2026-22741, CVE-2026-22745 | spring-webmvc | No fix available |
+| #77 | CVE-2025-11143 | jetty-http | No 9.x fix |
+| #40 | CVE-2024-6763 | jetty-http | Fix is Jetty 12 only |

--- a/langsmith-java-core/build.gradle.kts
+++ b/langsmith-java-core/build.gradle.kts
@@ -48,10 +48,10 @@ dependencies {
     implementation("org.apache.httpcomponents.client5:httpclient5:5.3.1")
 
     // OpenTelemetry dependencies
-    api("io.opentelemetry:opentelemetry-api:1.32.0")
-    api("io.opentelemetry:opentelemetry-sdk:1.32.0")
-    api("io.opentelemetry:opentelemetry-exporter-otlp:1.32.0")
-    api("io.opentelemetry.semconv:opentelemetry-semconv:1.23.1-alpha")
+    api("io.opentelemetry:opentelemetry-api:1.62.0")
+    api("io.opentelemetry:opentelemetry-sdk:1.62.0")
+    api("io.opentelemetry:opentelemetry-exporter-otlp:1.62.0")
+    api("io.opentelemetry.semconv:opentelemetry-semconv:1.41.1")
 
     // OpenAI SDK (for wrapOpenAI tracing wrapper)
     api("com.openai:openai-java:4.30.0")
@@ -71,12 +71,12 @@ dependencies {
     // These constraints apply to the test scope only and do not affect published artifacts.
     constraints {
         // CVE-2024-13009, CVE-2025-5115, CVE-2024-22201, CVE-2023-36478
-        testImplementation("org.eclipse.jetty:jetty-server") { version { require("9.4.57.v20241219") } }
-        testImplementation("org.eclipse.jetty.http2:http2-common") { version { require("9.4.57.v20241219") } }
-        testImplementation("org.eclipse.jetty.http2:http2-hpack") { version { require("9.4.57.v20241219") } }
-        // CVE-2023-6481, CVE-2023-6378
-        testImplementation("ch.qos.logback:logback-core") { version { require("1.2.13") } }
-        testImplementation("ch.qos.logback:logback-classic") { version { require("1.2.13") } }
+        testImplementation("org.eclipse.jetty:jetty-server") { version { require("9.4.58.v20250814") } }
+        testImplementation("org.eclipse.jetty.http2:http2-common") { version { require("9.4.58.v20250814") } }
+        testImplementation("org.eclipse.jetty.http2:http2-hpack") { version { require("9.4.58.v20250814") } }
+        // CVE-2023-6481, CVE-2023-6378, CVE-2025-11226, CVE-2024-12798, CVE-2024-12801, CVE-2026-1225
+        testImplementation("ch.qos.logback:logback-core") { version { require("1.5.32") } }
+        testImplementation("ch.qos.logback:logback-classic") { version { require("1.5.32") } }
         // CVE-2025-48976, CVE-2023-24998
         testImplementation("commons-fileupload:commons-fileupload") { version { require("1.6.0") } }
         // CVE-2024-47554

--- a/langsmith-java-core/src/main/kotlin/com/langchain/smith/otel/OtelTraceExporter.kt
+++ b/langsmith-java-core/src/main/kotlin/com/langchain/smith/otel/OtelTraceExporter.kt
@@ -8,7 +8,7 @@ import io.opentelemetry.sdk.common.CompletableResultCode
 import io.opentelemetry.sdk.resources.Resource
 import io.opentelemetry.sdk.trace.SdkTracerProvider
 import io.opentelemetry.sdk.trace.export.BatchSpanProcessor
-import io.opentelemetry.semconv.ResourceAttributes
+import io.opentelemetry.semconv.ServiceAttributes
 import java.time.Duration
 import java.util.concurrent.TimeUnit
 import org.slf4j.LoggerFactory
@@ -46,8 +46,8 @@ private constructor(
             val resource =
                 Resource.getDefault()
                     .toBuilder()
-                    .put(ResourceAttributes.SERVICE_NAME, serviceName)
-                    .put(ResourceAttributes.SERVICE_VERSION, INSTRUMENTATION_VERSION)
+                    .put(ServiceAttributes.SERVICE_NAME, serviceName)
+                    .put(ServiceAttributes.SERVICE_VERSION, INSTRUMENTATION_VERSION)
                     .build()
 
             if (!config.enabled) {

--- a/langsmith-java-example/build.gradle.kts
+++ b/langsmith-java-example/build.gradle.kts
@@ -35,19 +35,24 @@ dependencies {
     // None of these affect published artifacts (this is a non-published example module).
     constraints {
         // CVE-2025-24813 (CRITICAL), CVE-2026-24734, CVE-2025-55752, CVE-2025-53506,
-        // CVE-2025-52520, CVE-2025-48989, CVE-2025-48988, CVE-2024-56337, CVE-2024-50379, CVE-2024-34750
+        // CVE-2025-52520, CVE-2025-48989, CVE-2025-48988, CVE-2024-56337, CVE-2024-50379, CVE-2024-34750,
+        // CVE-2026-29145, CVE-2026-29129, CVE-2026-34483, CVE-2026-34487, CVE-2026-34500, CVE-2026-32990,
+        // CVE-2026-25854, CVE-2026-41284, CVE-2026-41293, CVE-2026-42498, CVE-2026-43512, CVE-2026-43513,
+        // CVE-2026-43514, CVE-2026-43515
         // Remove this constraint when upgrading to Spring Boot 3.x (which manages Tomcat 10+).
-        implementation("org.apache.tomcat.embed:tomcat-embed-core") { version { require("9.0.115") } }
-        implementation("org.apache.tomcat.embed:tomcat-embed-websocket") { version { require("9.0.115") } }
-        // CVE-2024-22243, CVE-2024-22259, CVE-2024-22262
+        implementation("org.apache.tomcat.embed:tomcat-embed-core") { version { require("9.0.118") } }
+        implementation("org.apache.tomcat.embed:tomcat-embed-websocket") { version { require("9.0.118") } }
+        // CVE-2024-22243, CVE-2024-22259, CVE-2024-22262, CVE-2024-38809, CVE-2024-38808
         // Note: CVE-2016-1000027 (CRITICAL) requires spring-web 6.0.0 — needs Spring Boot 3.x upgrade.
-        implementation("org.springframework:spring-web") { version { require("5.3.34") } }
-        implementation("org.springframework:spring-webmvc") { version { require("5.3.34") } }
-        // CVE-2023-6481, CVE-2023-6378
-        implementation("ch.qos.logback:logback-core") { version { require("1.2.13") } }
-        implementation("ch.qos.logback:logback-classic") { version { require("1.2.13") } }
-        // CVE-2022-25857 (note: CVE-2022-1471 requires snakeyaml 2.0 which is incompatible with Spring Boot 2.7.x)
-        implementation("org.yaml:snakeyaml") { version { require("1.31") } }
+        implementation("org.springframework:spring-web") { version { require("5.3.39") } }
+        implementation("org.springframework:spring-webmvc") { version { require("5.3.39") } }
+        implementation("org.springframework:spring-expression") { version { require("5.3.39") } }
+        // CVE-2023-6481, CVE-2023-6378, CVE-2025-11226, CVE-2024-12798, CVE-2024-12801, CVE-2026-1225
+        implementation("ch.qos.logback:logback-core") { version { require("1.5.32") } }
+        implementation("ch.qos.logback:logback-classic") { version { require("1.5.32") } }
+        // CVE-2022-25857, CVE-2022-38752, CVE-2022-41854
+        // (note: CVE-2022-1471 requires snakeyaml 2.0 which is incompatible with Spring Boot 2.7.x)
+        implementation("org.yaml:snakeyaml") { version { require("1.32") } }
     }
 }
 


### PR DESCRIPTION
## Security Alert Patch

Resolves Dependabot security alerts across critical + high severity tiers, validated against actual dependency versions in the build files.

### Packages Updated

| Package | Old Version | New Version | Strategy | Scope | CVEs Resolved |
|---------|------------|-------------|----------|-------|---------------|
| `opentelemetry-api/sdk/exporter-otlp` | 1.32.0 | 1.62.0 | Direct bump (A) | **Published** | CVE-2026-45292 |
| `opentelemetry-semconv` | 1.23.1-alpha | 1.41.1 | Direct bump (A) | Published | semconv GA migration |
| `jetty-server` | 9.4.57.v20241219 | 9.4.58.v20250814 | Override (C, test-only) | Test scope | CVE-2025-5115 |
| `http2-common`, `http2-hpack` | 9.4.57.v20241219 | 9.4.58.v20250814 | Override (C, test-only) | Test scope | CVE-2025-5115 |
| `logback-core`, `logback-classic` | 1.2.13 | 1.5.32 | Override (C, test+example) | Test + example | CVE-2025-11226, CVE-2024-12798, CVE-2024-12801, CVE-2026-1225 |
| `tomcat-embed-core`, `tomcat-embed-websocket` | 9.0.115 | 9.0.118 | Override (C, example) | Example only | 14 alerts (4 critical, 6 high) |
| `spring-web`, `spring-webmvc` | 5.3.34 | 5.3.39 | Override (C, example) | Example only | CVE-2024-38809, CVE-2024-38808 |
| `spring-expression` | (unconstrained) | 5.3.39 | Override (C, example) | Example only | CVE-2024-38808 |
| `snakeyaml` | 1.31 | 1.32 | Override (C, example) | Example only | CVE-2022-38752, CVE-2022-41854 |

### Source change

`OtelTraceExporter.kt`: `ResourceAttributes` → `ServiceAttributes` (the `ResourceAttributes` class was removed in `opentelemetry-semconv` 1.30.0 when semconv went stable GA; `SERVICE_NAME` and `SERVICE_VERSION` moved to `ServiceAttributes`).

### Logback note

The previous `1.2.13` pin was placed to avoid CVE-2023-6481/CVE-2023-6378, which affect logback 1.3.0–1.3.11. Those CVEs were fixed in 1.3.12. Bumping to `1.5.32` (latest) is safe and closes four newer CVEs that 1.2.13 leaves open.

### CVE Details

| CVE | Package | Summary |
|-----|---------|---------|
| CVE-2026-45292 | opentelemetry-api | Unbounded Memory Allocation in W3C Baggage Propagation |
| CVE-2025-5115 | http2-common | MadeYouReset HTTP/2 vulnerability |
| CVE-2025-11226 | logback-core | Arbitrary Code Execution through file processing |
| CVE-2024-12798 | logback-core | Expression Language Injection |
| CVE-2024-12801 | logback-core | Server-Side Request Forgery |
| CVE-2026-1225 | logback-core | Attacker can instantiate classes on the class path |
| CVE-2026-29145/29129/34483/34487/34500/32990/25854 | tomcat-embed-core | Various Tomcat 9.0.116–9.0.118 fixes |
| CVE-2026-41284/41293/42498/43512/43513/43514/43515 | tomcat-embed-core | Various Tomcat 9.0.118 fixes |
| CVE-2024-38809/38808 | spring-web/expression | DoS via conditional HTTP / SpEL DoS |
| CVE-2022-38752/41854 | snakeyaml | Stack overflow / DoS |

### Stale alerts (already fixed — can be dismissed on GitHub)

15 alerts show as open but are already addressed by existing constraints: CVE-2024-13009, CVE-2024-8184, CVE-2023-44487 (×2), CVE-2024-22201, CVE-2023-36478, CVE-2023-26049, CVE-2023-26048, CVE-2025-48976, CVE-2023-24998, CVE-2024-47554, CVE-2023-1370, CVE-2025-52999, GHSA-72hv-8253-57qq (×2).

See `SECURITY_FIX_PLAN.md` for full status including no-fix-available alerts.

### No-fix-available alerts (Spring 5.x + Jetty 9.x limitations)

17 alerts remain open with `first_patched_version: null`. These require a Spring Boot 3.x upgrade (example module) or Jetty major version bump. They are tracked in `SECURITY_FIX_PLAN.md`.

### Verification

- [ ] All constraint version bumps use minimum safe version
- [ ] OTel semconv API migration verified against semconv 1.41.1 JAR
- [ ] No published artifact constraints changed (only test/example scope), except OTel which is the intentional P1 fix
- [ ] CI will be the build verification gate (no JDK in patch environment)

🤖 Submitted by langster-patch