### PR TITLE
fix: restore dokka-javadoc plugin application to subprojects

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -26,6 +26,7 @@ subprojects {
 
 subprojects {
     apply(plugin = "org.jetbrains.dokka")
+    apply(plugin = "org.jetbrains.dokka-javadoc")
 }
 
 // Avoid race conditions between `dokkaJavadocCollector` and `dokkaJavadocJar` tasks

--- a/langsmith-java-client-okhttp/src/main/kotlin/com/langchain/smith/client/okhttp/LangsmithOkHttpClient.kt
+++ b/langsmith-java-client-okhttp/src/main/kotlin/com/langchain/smith/client/okhttp/LangsmithOkHttpClient.kt
@@ -310,7 +310,6 @@ class LangsmithOkHttpClient private constructor() {
          */
         fun logLevel(logLevel: LogLevel) = apply { clientOptions.logLevel(logLevel) }
 
-
         fun apiKey(apiKey: String?) = apply { clientOptions.apiKey(apiKey) }
 
         /** Alias for calling [Builder.apiKey] with `apiKey.orElse(null)`. */

--- a/langsmith-java-client-okhttp/src/main/kotlin/com/langchain/smith/client/okhttp/LangsmithOkHttpClientAsync.kt
+++ b/langsmith-java-client-okhttp/src/main/kotlin/com/langchain/smith/client/okhttp/LangsmithOkHttpClientAsync.kt
@@ -310,7 +310,6 @@ class LangsmithOkHttpClientAsync private constructor() {
          */
         fun logLevel(logLevel: LogLevel) = apply { clientOptions.logLevel(logLevel) }
 
-
         fun apiKey(apiKey: String?) = apply { clientOptions.apiKey(apiKey) }
 
         /** Alias for calling [Builder.apiKey] with `apiKey.orElse(null)`. */

--- a/langsmith-java-core/src/main/kotlin/com/langchain/smith/core/ClientOptions.kt
+++ b/langsmith-java-core/src/main/kotlin/com/langchain/smith/core/ClientOptions.kt
@@ -352,7 +352,6 @@ private constructor(
          */
         fun logLevel(logLevel: LogLevel) = apply { this.logLevel = logLevel }
 
-
         fun apiKey(apiKey: String?) = apply { this.apiKey = apiKey }
 
         /** Alias for calling [Builder.apiKey] with `apiKey.orElse(null)`. */


### PR DESCRIPTION
## Summary

- Commit [`b1af8d8`](https://github.com/langchain-ai/langsmith-java/commit/b1af8d842d8aa3b1a47cb00ffa22d71134b0d883) ("remove duplicated dokka setup") removed `apply(plugin = "org.jetbrains.dokka-javadoc")` from the `subprojects` block, thinking the root-level `plugins {}` declaration was sufficient.
- The root `plugins {}` block applies the plugin to the root project only. Each subproject needs the plugin applied individually to register the `dokkaGeneratePublicationJavadoc` task.
- `langchain.publish.gradle.kts` depends on that task via `JavadocJar.Dokka("dokkaGeneratePublicationJavadoc")`, so every subproject applying `langchain.publish` fails at configuration time.

## Error fixed

```
An exception occurred applying plugin request [id: 'langchain.publish']
> Failed to apply plugin 'langchain.publish'.
   > Could not create task ':langsmith-java:dokkaJavadocJar'.
      > Task with name 'dokkaGeneratePublicationJavadoc' not found in project ':langsmith-java'.
```

This is currently breaking the release PR #156.