### PR TITLE
LSDK-227 Add Java experiment runner

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,36 @@ for (var run : response.runs()) {
 }
 ```
 
+### Running evaluations
+
+Use `ExperimentClient.evaluate` to run a target function over a dataset, record the experiment, and
+upload local evaluator feedback.
+
+```java
+import com.langchain.smith.evaluation.EvaluateParams;
+import com.langchain.smith.evaluation.EvaluationResult;
+import com.langchain.smith.evaluation.ExperimentClient;
+import com.langchain.smith.evaluation.ExperimentResults;
+import java.util.Collections;
+import java.util.Objects;
+
+ExperimentResults results = ExperimentClient.create(client).evaluate(
+    EvaluateParams.builder()
+        .data("my-dataset")
+        .experimentPrefix("java-evaluate")
+        .target(example -> Collections.singletonMap("answer", "Paris"))
+        .addEvaluator((run, example) ->
+            EvaluationResult.builder()
+                .key("exact_match")
+                .score(Objects.equals(run.outputs().get("answer"), example.outputs().get("answer")))
+                .build())
+        .build());
+
+System.out.println("Experiment: " + results.experimentId());
+System.out.println("Rows: " + results.rows().size());
+System.out.println("Feedback: " + results.feedback().size());
+```
+
 ## Examples
 
 This repository includes runnable examples in the `langsmith-java-example` module to help you get started.
@@ -91,6 +121,9 @@ export LANGSMITH_ENDPOINT="https://api.smith.langchain.com"
 ```bash
 export LANGSMITH_PROJECT_ID="your-project-id"
 ./gradlew :langsmith-java-example:run -Pexample=ListRuns
+
+# Run a high-level experiment with a target function and local evaluator
+./gradlew :langsmith-java-example:run -Pexample=RunExperiment
 ```
 
 All examples are available in [`langsmith-java-example`](langsmith-java-example).

--- a/README.md
+++ b/README.md
@@ -69,36 +69,6 @@ for (var run : response.runs()) {
 }
 ```
 
-### Running evaluations
-
-Use `ExperimentClient.evaluate` to run a target function over a dataset, record the experiment, and
-upload local evaluator feedback.
-
-```java
-import com.langchain.smith.evaluation.EvaluateParams;
-import com.langchain.smith.evaluation.EvaluationResult;
-import com.langchain.smith.evaluation.ExperimentClient;
-import com.langchain.smith.evaluation.ExperimentResults;
-import java.util.Collections;
-import java.util.Objects;
-
-ExperimentResults results = ExperimentClient.create(client).evaluate(
-    EvaluateParams.builder()
-        .data("my-dataset")
-        .experimentPrefix("java-evaluate")
-        .target(example -> Collections.singletonMap("answer", "Paris"))
-        .addEvaluator((run, example) ->
-            EvaluationResult.builder()
-                .key("exact_match")
-                .score(Objects.equals(run.outputs().get("answer"), example.outputs().get("answer")))
-                .build())
-        .build());
-
-System.out.println("Experiment: " + results.experimentId());
-System.out.println("Rows: " + results.rows().size());
-System.out.println("Feedback: " + results.feedback().size());
-```
-
 ## Examples
 
 This repository includes runnable examples in the `langsmith-java-example` module to help you get started.
@@ -121,9 +91,6 @@ export LANGSMITH_ENDPOINT="https://api.smith.langchain.com"
 ```bash
 export LANGSMITH_PROJECT_ID="your-project-id"
 ./gradlew :langsmith-java-example:run -Pexample=ListRuns
-
-# Run a high-level experiment with a target function and local evaluator
-./gradlew :langsmith-java-example:run -Pexample=RunExperiment
 ```
 
 All examples are available in [`langsmith-java-example`](langsmith-java-example).

--- a/langsmith-java-core/src/main/kotlin/com/langchain/smith/evaluation/EvaluateParams.kt
+++ b/langsmith-java-core/src/main/kotlin/com/langchain/smith/evaluation/EvaluateParams.kt
@@ -1,0 +1,169 @@
+package com.langchain.smith.evaluation
+
+import com.langchain.smith.models.examples.Example
+import java.util.Optional
+import kotlin.jvm.optionals.getOrNull
+
+/** Parameters for [ExperimentClient.evaluate]. */
+class EvaluateParams
+private constructor(
+    private val data: String?,
+    private val examples: List<Example>?,
+    private val target: ExperimentTarget,
+    private val evaluators: List<RunEvaluator>,
+    private val experimentName: String?,
+    private val experimentPrefix: String?,
+    private val description: String?,
+    private val metadata: Map<String, Any?>,
+    private val tags: List<String>,
+    private val maxConcurrency: Int,
+    private val batchSize: Int,
+    private val errorHandling: ErrorHandling,
+) {
+
+    fun data(): Optional<String> = Optional.ofNullable(data)
+
+    fun examples(): Optional<List<Example>> = Optional.ofNullable(examples)
+
+    fun target(): ExperimentTarget = target
+
+    fun evaluators(): List<RunEvaluator> = evaluators
+
+    fun experimentName(): Optional<String> = Optional.ofNullable(experimentName)
+
+    fun experimentPrefix(): Optional<String> = Optional.ofNullable(experimentPrefix)
+
+    fun description(): Optional<String> = Optional.ofNullable(description)
+
+    fun metadata(): Map<String, Any?> = metadata
+
+    fun tags(): List<String> = tags
+
+    fun maxConcurrency(): Int = maxConcurrency
+
+    fun batchSize(): Int = batchSize
+
+    fun errorHandling(): ErrorHandling = errorHandling
+
+    fun toBuilder(): Builder = Builder().from(this)
+
+    companion object {
+
+        @JvmStatic fun builder(): Builder = Builder()
+    }
+
+    class Builder internal constructor() {
+
+        private var data: String? = null
+        private var examples: List<Example>? = null
+        private var target: ExperimentTarget? = null
+        private var evaluators: MutableList<RunEvaluator> = mutableListOf()
+        private var experimentName: String? = null
+        private var experimentPrefix: String? = null
+        private var description: String? = null
+        private var metadata: MutableMap<String, Any?> = mutableMapOf()
+        private var tags: MutableList<String> = mutableListOf()
+        private var maxConcurrency: Int = 0
+        private var batchSize: Int = 100
+        private var errorHandling: ErrorHandling = ErrorHandling.LOG
+
+        internal fun from(params: EvaluateParams) = apply {
+            data = params.data
+            examples = params.examples
+            target = params.target
+            evaluators = params.evaluators.toMutableList()
+            experimentName = params.experimentName
+            experimentPrefix = params.experimentPrefix
+            description = params.description
+            metadata = params.metadata.toMutableMap()
+            tags = params.tags.toMutableList()
+            maxConcurrency = params.maxConcurrency
+            batchSize = params.batchSize
+            errorHandling = params.errorHandling
+        }
+
+        fun data(data: String?) = apply { this.data = data }
+
+        fun data(data: Optional<String>) = data(data.getOrNull())
+
+        fun examples(examples: Iterable<Example>?) = apply { this.examples = examples?.toList() }
+
+        fun examples(examples: Optional<out Iterable<Example>>) = examples(examples.getOrNull())
+
+        fun target(target: ExperimentTarget) = apply { this.target = target }
+
+        fun evaluators(evaluators: Iterable<RunEvaluator>) = apply {
+            this.evaluators = evaluators.toMutableList()
+        }
+
+        fun addEvaluator(evaluator: RunEvaluator) = apply { evaluators.add(evaluator) }
+
+        fun experimentName(experimentName: String?) = apply { this.experimentName = experimentName }
+
+        fun experimentName(experimentName: Optional<String>) =
+            experimentName(experimentName.getOrNull())
+
+        fun experimentPrefix(experimentPrefix: String?) = apply {
+            this.experimentPrefix = experimentPrefix
+        }
+
+        fun experimentPrefix(experimentPrefix: Optional<String>) =
+            experimentPrefix(experimentPrefix.getOrNull())
+
+        fun description(description: String?) = apply { this.description = description }
+
+        fun description(description: Optional<String>) = description(description.getOrNull())
+
+        fun metadata(metadata: Map<String, Any?>) = apply {
+            this.metadata.clear()
+            putAllMetadata(metadata)
+        }
+
+        fun putMetadata(key: String, value: Any?) = apply { metadata[key] = value }
+
+        fun putAllMetadata(metadata: Map<String, Any?>) = apply { this.metadata.putAll(metadata) }
+
+        fun tags(tags: Iterable<String>) = apply { this.tags = tags.toMutableList() }
+
+        fun addTag(tag: String) = apply { tags.add(tag) }
+
+        fun maxConcurrency(maxConcurrency: Int) = apply {
+            require(maxConcurrency >= 0) { "maxConcurrency must be greater than or equal to 0" }
+            this.maxConcurrency = maxConcurrency
+        }
+
+        fun batchSize(batchSize: Int) = apply {
+            require(batchSize > 0) { "batchSize must be greater than 0" }
+            this.batchSize = batchSize
+        }
+
+        fun errorHandling(errorHandling: ErrorHandling) = apply {
+            this.errorHandling = errorHandling
+        }
+
+        fun build(): EvaluateParams {
+            require(data != null || examples != null) { "Either data or examples must be set" }
+            require(data == null || examples == null) { "Only one of data or examples may be set" }
+            require(!data.isNullOrBlank() || examples != null) { "data must not be blank" }
+            return EvaluateParams(
+                data = data,
+                examples = examples,
+                target = requireNotNull(target) { "target must be set" },
+                evaluators = evaluators.toList(),
+                experimentName = experimentName,
+                experimentPrefix = experimentPrefix,
+                description = description,
+                metadata = metadata.toMap(),
+                tags = tags.toList(),
+                maxConcurrency = maxConcurrency,
+                batchSize = batchSize,
+                errorHandling = errorHandling,
+            )
+        }
+    }
+}
+
+enum class ErrorHandling {
+    LOG,
+    IGNORE,
+}

--- a/langsmith-java-core/src/main/kotlin/com/langchain/smith/evaluation/EvaluationResult.kt
+++ b/langsmith-java-core/src/main/kotlin/com/langchain/smith/evaluation/EvaluationResult.kt
@@ -1,0 +1,75 @@
+package com.langchain.smith.evaluation
+
+import java.util.Optional
+
+/** A single row-level evaluation metric to submit as LangSmith feedback. */
+class EvaluationResult
+private constructor(
+    private val key: String,
+    private val score: Any?,
+    private val value: Any?,
+    private val comment: String?,
+    private val correction: Any?,
+) {
+
+    fun key(): String = key
+
+    fun score(): Optional<Any> = Optional.ofNullable(score)
+
+    fun value(): Optional<Any> = Optional.ofNullable(value)
+
+    fun comment(): Optional<String> = Optional.ofNullable(comment)
+
+    fun correction(): Optional<Any> = Optional.ofNullable(correction)
+
+    fun toBuilder(): Builder = Builder().from(this)
+
+    companion object {
+
+        @JvmStatic fun builder(): Builder = Builder()
+    }
+
+    class Builder internal constructor() {
+
+        private var key: String? = null
+        private var score: Any? = null
+        private var value: Any? = null
+        private var comment: String? = null
+        private var correction: Any? = null
+
+        internal fun from(result: EvaluationResult) = apply {
+            key = result.key
+            score = result.score
+            value = result.value
+            comment = result.comment
+            correction = result.correction
+        }
+
+        fun key(key: String) = apply { this.key = key }
+
+        fun score(score: Double) = apply { this.score = score }
+
+        fun score(score: Boolean) = apply { this.score = score }
+
+        fun value(value: Double) = apply { this.value = value }
+
+        fun value(value: Boolean) = apply { this.value = value }
+
+        fun value(value: String) = apply { this.value = value }
+
+        fun comment(comment: String?) = apply { this.comment = comment }
+
+        fun correction(correction: String?) = apply { this.correction = correction }
+
+        fun correction(correction: Map<String, Any?>) = apply { this.correction = correction }
+
+        fun build(): EvaluationResult =
+            EvaluationResult(
+                key = requireNotNull(key) { "key must be set" },
+                score = score,
+                value = value,
+                comment = comment,
+                correction = correction,
+            )
+    }
+}

--- a/langsmith-java-core/src/main/kotlin/com/langchain/smith/evaluation/ExperimentClient.kt
+++ b/langsmith-java-core/src/main/kotlin/com/langchain/smith/evaluation/ExperimentClient.kt
@@ -1,0 +1,393 @@
+package com.langchain.smith.evaluation
+
+import com.langchain.smith.client.LangsmithClient
+import com.langchain.smith.core.JsonValue
+import com.langchain.smith.models.datasets.DatasetListParams
+import com.langchain.smith.models.examples.Example
+import com.langchain.smith.models.examples.ExampleListParams
+import com.langchain.smith.models.feedback.FeedbackCreateSchema
+import com.langchain.smith.models.feedback.FeedbackSchema
+import com.langchain.smith.models.runs.Run
+import com.langchain.smith.models.runs.RunIngestBatchParams
+import com.langchain.smith.models.sessions.SessionCreateParams
+import com.langchain.smith.models.sessions.SessionUpdateParams
+import com.langchain.smith.models.sessions.TracerSessionWithoutVirtualFields
+import java.time.OffsetDateTime
+import java.time.ZoneOffset
+import java.time.format.DateTimeFormatter
+import java.util.UUID
+import java.util.concurrent.Callable
+import java.util.concurrent.Executors
+import kotlin.jvm.optionals.getOrNull
+
+/** High-level client for running LangSmith experiments over dataset examples. */
+class ExperimentClient private constructor(private val client: LangsmithClient) {
+
+    /** Runs a synchronous experiment and uploads runs plus evaluator feedback to LangSmith. */
+    fun evaluate(params: EvaluateParams): ExperimentResults {
+        val examples = resolveExamples(params)
+        require(examples.isNotEmpty()) { "Evaluation data must contain at least one example" }
+        requireSingleDataset(examples)
+
+        val session = createSession(params, examples.first())
+        val results =
+            try {
+                val rows = runTargets(params, session, examples)
+
+                ingestRuns(rows.map { it.run() }, params.batchSize())
+                val feedback = runEvaluators(params, rows)
+                ExperimentResults(session = session, rows = rows, feedback = feedback)
+            } catch (e: Throwable) {
+                updateSessionEndTimeSuppressing(session, e)
+                throw e
+            }
+
+        updateSessionEndTime(session)
+        return results
+    }
+
+    private fun requireSingleDataset(examples: List<ExperimentExample>) {
+        val datasetIds = examples.map { it.datasetId() }.distinct()
+        require(datasetIds.size == 1) {
+            "Evaluation examples must all belong to the same dataset; found ${datasetIds.size}"
+        }
+    }
+
+    private fun resolveExamples(params: EvaluateParams): List<ExperimentExample> =
+        params.examples().getOrNull()?.map { ExperimentExample(it) }
+            ?: client
+                .examples()
+                .list(
+                    ExampleListParams.builder()
+                        .dataset(datasetId(requireNotNull(params.data().getOrNull())))
+                        .build()
+                )
+                .autoPager()
+                .map { ExperimentExample(it) }
+                .toList()
+
+    private fun datasetId(data: String): String {
+        if (data.isUuid()) return data
+
+        val dataset =
+            client
+                .datasets()
+                .list(DatasetListParams.builder().name(data).limit(1).build())
+                .items()
+                .firstOrNull()
+        require(dataset != null) { "Dataset not found: $data" }
+        return dataset.id()
+    }
+
+    private fun createSession(
+        params: EvaluateParams,
+        firstExample: ExperimentExample,
+    ): TracerSessionWithoutVirtualFields {
+        val metadata = buildMetadata(params)
+        return client
+            .sessions()
+            .create(
+                SessionCreateParams.builder()
+                    .name(experimentName(params))
+                    .description(params.description().getOrNull())
+                    .startTime(OffsetDateTime.now(ZoneOffset.UTC))
+                    .referenceDatasetId(firstExample.datasetId())
+                    .extra(
+                        SessionCreateParams.Extra.builder()
+                            .putAdditionalProperty("metadata", JsonValue.from(metadata))
+                            .build()
+                    )
+                    .build()
+            )
+    }
+
+    private fun runTargets(
+        params: EvaluateParams,
+        session: TracerSessionWithoutVirtualFields,
+        examples: List<ExperimentExample>,
+    ): List<ExperimentResultRow> =
+        runInOrder(examples, params.maxConcurrency()) { example ->
+                runTarget(params, session, example)
+            }
+            .mapNotNull { it }
+
+    private fun runTarget(
+        params: EvaluateParams,
+        session: TracerSessionWithoutVirtualFields,
+        example: ExperimentExample,
+    ): ExperimentResultRow? {
+        val startTime = OffsetDateTime.now(ZoneOffset.UTC)
+        val runId = UUID.randomUUID().toString()
+        return try {
+            val outputs = params.target().run(example).toMap()
+            val run =
+                buildRun(
+                    params = params,
+                    session = session,
+                    example = example,
+                    runId = runId,
+                    startTime = startTime,
+                    endTime = OffsetDateTime.now(ZoneOffset.UTC),
+                    outputs = outputs,
+                    error = null,
+                )
+            ExperimentResultRow(
+                example = example,
+                run = run,
+                evaluationResults = emptyList(),
+                targetError = null,
+                evaluatorErrors = emptyList(),
+            )
+        } catch (e: Throwable) {
+            if (params.errorHandling() == ErrorHandling.IGNORE) {
+                null
+            } else {
+                val run =
+                    buildRun(
+                        params = params,
+                        session = session,
+                        example = example,
+                        runId = runId,
+                        startTime = startTime,
+                        endTime = OffsetDateTime.now(ZoneOffset.UTC),
+                        outputs = null,
+                        error = e.stackTraceToString(),
+                    )
+                ExperimentResultRow(
+                    example = example,
+                    run = run,
+                    evaluationResults = emptyList(),
+                    targetError = e,
+                    evaluatorErrors = emptyList(),
+                )
+            }
+        }
+    }
+
+    private fun buildRun(
+        params: EvaluateParams,
+        session: TracerSessionWithoutVirtualFields,
+        example: ExperimentExample,
+        runId: String,
+        startTime: OffsetDateTime,
+        endTime: OffsetDateTime,
+        outputs: Map<String, Any?>?,
+        error: String?,
+    ): Run {
+        val metadata =
+            buildMap<String, Any?> {
+                putAll(buildMetadata(params))
+                example.modifiedAt().ifPresent { put("example_version", it.toString()) }
+            }
+
+        return Run.builder()
+            .id(runId)
+            .traceId(runId)
+            .dottedOrder(dottedOrder(startTime, runId))
+            .name("Target")
+            .runType(Run.RunType.CHAIN)
+            .sessionId(session.id())
+            .apply { session.name().ifPresent { sessionName(it) } }
+            .referenceExampleId(example.id())
+            .inputs(
+                Run.Inputs.builder()
+                    .putAllAdditionalProperties(toJsonValueMap(example.inputs()))
+                    .build()
+            )
+            .apply {
+                outputs?.let {
+                    outputs(
+                        Run.Outputs.builder().putAllAdditionalProperties(toJsonValueMap(it)).build()
+                    )
+                }
+            }
+            .startTime(startTime.format(DateTimeFormatter.ISO_OFFSET_DATE_TIME))
+            .endTime(endTime.format(DateTimeFormatter.ISO_OFFSET_DATE_TIME))
+            .tags(params.tags())
+            .extra(
+                Run.Extra.builder()
+                    .putAdditionalProperty("metadata", JsonValue.from(metadata))
+                    .build()
+            )
+            .apply { error?.let { error(it) } }
+            .build()
+    }
+
+    private fun ingestRuns(runs: List<Run>, batchSize: Int) {
+        runs.chunked(batchSize).forEach { batch ->
+            val ingestParams =
+                RunIngestBatchParams.builder().apply { batch.forEach { addPost(it) } }.build()
+            client.runs().ingestBatch(ingestParams)
+        }
+    }
+
+    private fun runEvaluators(
+        params: EvaluateParams,
+        rows: List<ExperimentResultRow>,
+    ): List<FeedbackSchema> {
+        if (params.evaluators().isEmpty()) return emptyList()
+
+        val evaluatedRows =
+            runInOrder(rows, params.maxConcurrency()) { row ->
+                if (row.targetError().isPresent) row else evaluateRow(params, row)
+            }
+
+        rows.zip(evaluatedRows).forEach { (original, evaluated) -> original.replaceWith(evaluated) }
+        return evaluatedRows.flatMap { row ->
+            row.evaluationResults().map { result -> createFeedback(row, result) }
+        }
+    }
+
+    private fun evaluateRow(params: EvaluateParams, row: ExperimentResultRow): ExperimentResultRow {
+        val experimentRun = ExperimentRun(row.run())
+        val results = mutableListOf<EvaluationResult>()
+        val errors = mutableListOf<EvaluatorError>()
+
+        params.evaluators().forEach { evaluator ->
+            try {
+                results.add(evaluator.evaluate(experimentRun, row.example()))
+            } catch (e: Throwable) {
+                errors.add(EvaluatorError(evaluator = evaluator, error = e))
+            }
+        }
+
+        return row.copy(evaluationResults = results, evaluatorErrors = errors)
+    }
+
+    private fun createFeedback(row: ExperimentResultRow, result: EvaluationResult): FeedbackSchema =
+        client.feedback().create(toFeedbackCreateSchema(row, result))
+
+    private fun toFeedbackCreateSchema(
+        row: ExperimentResultRow,
+        result: EvaluationResult,
+    ): FeedbackCreateSchema {
+        val builder =
+            FeedbackCreateSchema.builder()
+                .key(result.key())
+                .runId(requireNotNull(row.run().id().getOrNull()))
+                .traceId(requireNotNull(row.run().traceId().getOrNull()))
+                .sessionId(row.run().sessionId().getOrNull())
+
+        result.comment().ifPresent { builder.comment(it) }
+        result.score().ifPresent {
+            when (it) {
+                is Boolean -> builder.score(it)
+                is Number -> builder.score(it.toDouble())
+            }
+        }
+        result.value().ifPresent {
+            when (it) {
+                is Boolean -> builder.value(it)
+                is Number -> builder.value(it.toDouble())
+                is String -> builder.value(it)
+            }
+        }
+        result.correction().ifPresent {
+            when (it) {
+                is String -> builder.correction(it)
+                is Map<*, *> ->
+                    builder.correction(
+                        FeedbackCreateSchema.Correction.UnionMember0.builder()
+                            .putAllAdditionalProperties(toStringKeyedJsonValueMap(it))
+                            .build()
+                    )
+            }
+        }
+
+        return builder.build()
+    }
+
+    private fun updateSessionEndTime(session: TracerSessionWithoutVirtualFields) {
+        client
+            .sessions()
+            .update(
+                SessionUpdateParams.builder()
+                    .sessionId(session.id())
+                    .endTime(OffsetDateTime.now(ZoneOffset.UTC))
+                    .build()
+            )
+    }
+
+    private fun updateSessionEndTimeSuppressing(
+        session: TracerSessionWithoutVirtualFields,
+        failure: Throwable,
+    ) {
+        try {
+            updateSessionEndTime(session)
+        } catch (updateFailure: Throwable) {
+            failure.addSuppressed(updateFailure)
+        }
+    }
+
+    private fun experimentName(params: EvaluateParams): String =
+        params.experimentName().getOrNull()
+            ?: "${params.experimentPrefix().orElse("java-evaluate")}-${randomNameSuffix()}"
+
+    private fun randomNameSuffix(): String = UUID.randomUUID().toString().take(8)
+
+    private fun buildMetadata(params: EvaluateParams): Map<String, Any?> = buildMap {
+        put("__ls_runner", "java_sdk_evaluate")
+        putAll(params.metadata())
+    }
+
+    private fun <T, R> runInOrder(items: List<T>, maxConcurrency: Int, block: (T) -> R): List<R> {
+        if (maxConcurrency == 0 || items.size <= 1) return items.map(block)
+
+        val executor = Executors.newFixedThreadPool(maxConcurrency)
+        return try {
+            items.map { item -> executor.submit(Callable { block(item) }) }.map { it.get() }
+        } finally {
+            executor.shutdown()
+        }
+    }
+
+    companion object {
+
+        @JvmStatic fun create(client: LangsmithClient): ExperimentClient = ExperimentClient(client)
+    }
+}
+
+private val DOTTED_ORDER_FORMATTER = DateTimeFormatter.ofPattern("yyyyMMdd'T'HHmmssSSSSSS'Z'")
+
+private fun dottedOrder(startTime: OffsetDateTime, runId: String): String =
+    startTime.withOffsetSameInstant(ZoneOffset.UTC).format(DOTTED_ORDER_FORMATTER) + runId
+
+private fun toJsonValueMap(map: Map<String, Any?>): Map<String, JsonValue> =
+    map.mapValues { JsonValue.from(it.value) }
+
+private fun toStringKeyedJsonValueMap(map: Map<*, *>): Map<String, JsonValue> =
+    map.entries.associate { (key, value) ->
+        require(key is String) { "Correction maps must use string keys" }
+        key to JsonValue.from(value)
+    }
+
+private fun String.isUuid(): Boolean = runCatching { UUID.fromString(this) }.isSuccess
+
+internal fun JsonValue.toPlainValue(): Any? =
+    accept(
+        object : JsonValue.Visitor<Any?> {
+            override fun visitNull(): Any? = null
+
+            override fun visitMissing(): Any? = null
+
+            override fun visitBoolean(value: Boolean): Any = value
+
+            override fun visitNumber(value: Number): Any = value
+
+            override fun visitString(value: String): Any = value
+
+            override fun visitArray(values: List<JsonValue>): Any = values.map { it.toPlainValue() }
+
+            override fun visitObject(values: Map<String, JsonValue>): Any =
+                values.mapValues { it.value.toPlainValue() }
+        }
+    )
+
+internal fun Example.Inputs.toPlainMap(): Map<String, Any?> =
+    _additionalProperties().mapValues { it.value.toPlainValue() }
+
+internal fun Example.Outputs.toPlainMap(): Map<String, Any?> =
+    _additionalProperties().mapValues { it.value.toPlainValue() }
+
+internal fun Example.Metadata.toPlainMap(): Map<String, Any?> =
+    _additionalProperties().mapValues { it.value.toPlainValue() }

--- a/langsmith-java-core/src/main/kotlin/com/langchain/smith/evaluation/ExperimentTypes.kt
+++ b/langsmith-java-core/src/main/kotlin/com/langchain/smith/evaluation/ExperimentTypes.kt
@@ -1,0 +1,125 @@
+package com.langchain.smith.evaluation
+
+import com.langchain.smith.models.examples.Example
+import com.langchain.smith.models.feedback.FeedbackSchema
+import com.langchain.smith.models.runs.Run
+import com.langchain.smith.models.sessions.TracerSessionWithoutVirtualFields
+import java.time.OffsetDateTime
+import java.util.Optional
+import kotlin.jvm.optionals.getOrNull
+
+fun interface ExperimentTarget {
+    fun run(example: ExperimentExample): Map<String, Any?>
+}
+
+fun interface RunEvaluator {
+    fun evaluate(run: ExperimentRun, example: ExperimentExample): EvaluationResult
+}
+
+class ExperimentExample internal constructor(private val example: Example) {
+
+    fun example(): Example = example
+
+    fun id(): String = example.id()
+
+    fun datasetId(): String = example.datasetId()
+
+    fun inputs(): Map<String, Any?> = example.inputs().toPlainMap()
+
+    fun outputs(): Map<String, Any?> = example.outputs().getOrNull()?.toPlainMap() ?: emptyMap()
+
+    fun metadata(): Map<String, Any?> = example.metadata().getOrNull()?.toPlainMap() ?: emptyMap()
+
+    fun modifiedAt(): Optional<OffsetDateTime> = example.modifiedAt()
+}
+
+class ExperimentRun internal constructor(private val run: Run) {
+
+    fun run(): Run = run
+
+    fun id(): Optional<String> = run.id()
+
+    fun inputs(): Map<String, Any?> =
+        run.inputs().getOrNull()?._additionalProperties()?.mapValues { it.value.toPlainValue() }
+            ?: emptyMap()
+
+    fun outputs(): Map<String, Any?> =
+        run.outputs().getOrNull()?._additionalProperties()?.mapValues { it.value.toPlainValue() }
+            ?: emptyMap()
+}
+
+class ExperimentResults
+internal constructor(
+    private val session: TracerSessionWithoutVirtualFields,
+    private val rows: List<ExperimentResultRow>,
+    private val feedback: List<FeedbackSchema>,
+) {
+
+    fun session(): TracerSessionWithoutVirtualFields = session
+
+    fun experimentId(): String = session.id()
+
+    fun experimentName(): Optional<String> = session.name()
+
+    fun rows(): List<ExperimentResultRow> = rows
+
+    fun runs(): List<Run> = rows.map { it.run() }
+
+    fun feedback(): List<FeedbackSchema> = feedback
+
+    override fun toString(): String =
+        buildList {
+                add("experimentId=${session.id()}")
+                add("experimentName=${session.name()}")
+                add("rows=${rows.size}")
+                add("feedback=${feedback.size}")
+            }
+            .joinToString(", ", "ExperimentResults{", "}")
+}
+
+class ExperimentResultRow
+internal constructor(
+    private val example: ExperimentExample,
+    private var run: Run,
+    private var evaluationResults: List<EvaluationResult>,
+    private val targetError: Throwable?,
+    private var evaluatorErrors: List<EvaluatorError>,
+) {
+
+    fun example(): ExperimentExample = example
+
+    fun run(): Run = run
+
+    fun evaluationResults(): List<EvaluationResult> = evaluationResults
+
+    fun targetError(): Optional<Throwable> = Optional.ofNullable(targetError)
+
+    fun evaluatorErrors(): List<EvaluatorError> = evaluatorErrors
+
+    internal fun copy(
+        run: Run = this.run,
+        evaluationResults: List<EvaluationResult> = this.evaluationResults,
+        evaluatorErrors: List<EvaluatorError> = this.evaluatorErrors,
+    ): ExperimentResultRow =
+        ExperimentResultRow(
+            example = example,
+            run = run,
+            evaluationResults = evaluationResults,
+            targetError = targetError,
+            evaluatorErrors = evaluatorErrors,
+        )
+
+    internal fun replaceWith(row: ExperimentResultRow) {
+        run = row.run
+        evaluationResults = row.evaluationResults
+        evaluatorErrors = row.evaluatorErrors
+    }
+}
+
+class EvaluatorError
+internal constructor(private val evaluator: RunEvaluator, private val error: Throwable) {
+
+    fun evaluator(): RunEvaluator = evaluator
+
+    fun error(): Throwable = error
+}

--- a/langsmith-java-core/src/test/kotlin/com/langchain/smith/evaluation/ExperimentClientTest.kt
+++ b/langsmith-java-core/src/test/kotlin/com/langchain/smith/evaluation/ExperimentClientTest.kt
@@ -1,0 +1,454 @@
+package com.langchain.smith.evaluation
+
+import com.langchain.smith.client.LangsmithClient
+import com.langchain.smith.core.JsonValue
+import com.langchain.smith.models.datasets.Dataset
+import com.langchain.smith.models.datasets.DatasetListPage
+import com.langchain.smith.models.datasets.DatasetListParams
+import com.langchain.smith.models.examples.Example
+import com.langchain.smith.models.examples.ExampleListPage
+import com.langchain.smith.models.examples.ExampleListParams
+import com.langchain.smith.models.feedback.FeedbackCreateSchema
+import com.langchain.smith.models.feedback.FeedbackSchema
+import com.langchain.smith.models.runs.RunIngestBatchParams
+import com.langchain.smith.models.runs.RunIngestBatchResponse
+import com.langchain.smith.models.sessions.SessionCreateParams
+import com.langchain.smith.models.sessions.SessionUpdateParams
+import com.langchain.smith.models.sessions.TracerSessionWithoutVirtualFields
+import com.langchain.smith.services.blocking.DatasetService
+import com.langchain.smith.services.blocking.ExampleService
+import com.langchain.smith.services.blocking.FeedbackService
+import com.langchain.smith.services.blocking.RunService
+import com.langchain.smith.services.blocking.SessionService
+import java.util.UUID
+import java.util.concurrent.ConcurrentLinkedQueue
+import kotlin.jvm.optionals.getOrNull
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.argumentCaptor
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.times
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+
+internal class ExperimentClientTest {
+
+    private val client: LangsmithClient = mock()
+    private val datasetService: DatasetService = mock()
+    private val exampleService: ExampleService = mock()
+    private val sessionService: SessionService = mock()
+    private val runService: RunService = mock()
+    private val feedbackService: FeedbackService = mock()
+
+    @Test
+    fun evaluateWithExplicitExamplesCreatesSessionRunsAndFeedback() {
+        val examples = listOf(example(id = "ex-1", question = "2 + 2?", answer = "4"))
+        val subject = setupSubject()
+
+        val results =
+            subject.evaluate(
+                EvaluateParams.builder()
+                    .examples(examples)
+                    .experimentName("experiment-name")
+                    .putMetadata("revision_id", "abc123")
+                    .addTag("unit-test")
+                    .target { mapOf("answer" to "4") }
+                    .addEvaluator { run, example ->
+                        EvaluationResult.builder()
+                            .key("exact_match")
+                            .score(run.outputs()["answer"] == example.outputs()["answer"])
+                            .comment("matched")
+                            .build()
+                    }
+                    .build()
+            )
+
+        assertThat(results.experimentName()).contains("experiment-name")
+        assertThat(results.rows()).hasSize(1)
+        assertThat(results.feedback()).hasSize(1)
+        assertThat(results.rows()[0].evaluationResults().map { it.key() })
+            .containsExactly("exact_match")
+
+        val sessionCaptor = argumentCaptor<SessionCreateParams>()
+        verify(sessionService).create(sessionCaptor.capture())
+        assertThat(sessionCaptor.firstValue.name()).contains("experiment-name")
+        assertThat(sessionCaptor.firstValue.referenceDatasetId()).contains("dataset-id")
+        assertThat(sessionMetadata(sessionCaptor.firstValue))
+            .containsEntry("__ls_runner", "java_sdk_evaluate")
+            .containsEntry("revision_id", "abc123")
+
+        val batchCaptor = argumentCaptor<RunIngestBatchParams>()
+        verify(runService).ingestBatch(batchCaptor.capture())
+        val run = requireNotNull(batchCaptor.firstValue.post().getOrNull()).single()
+        assertThat(run.referenceExampleId()).contains("ex-1")
+        assertThat(run.sessionId()).contains("session-id")
+        assertThat(run.tags()).contains(listOf("unit-test"))
+        assertThat(
+                requireNotNull(run.outputs().getOrNull())
+                    ._additionalProperties()["answer"]
+                    ?.toPlainValue()
+            )
+            .isEqualTo("4")
+
+        val feedbackCaptor = argumentCaptor<FeedbackCreateSchema>()
+        verify(feedbackService).create(feedbackCaptor.capture())
+        assertThat(feedbackCaptor.firstValue.key()).isEqualTo("exact_match")
+        assertThat(feedbackCaptor.firstValue.runId()).contains(requireNotNull(run.id().getOrNull()))
+        assertThat(requireNotNull(feedbackCaptor.firstValue.score().getOrNull()).asBool()).isTrue()
+
+        verify(sessionService).update(any<SessionUpdateParams>())
+    }
+
+    @Test
+    fun evaluateWithDatasetNameLoadsExamplesByResolvedDatasetId() {
+        val subject =
+            setupSubject(
+                datasetPages = listOf(listOf(dataset(id = "dataset-id", name = "dataset-name"))),
+                examplePages = listOf(listOf(example("ex-1")), emptyList()),
+            )
+
+        subject.evaluate(
+            EvaluateParams.builder().data("dataset-name").target { mapOf("answer" to "4") }.build()
+        )
+
+        val datasetParamsCaptor = argumentCaptor<DatasetListParams>()
+        verify(datasetService).list(datasetParamsCaptor.capture())
+        assertThat(datasetParamsCaptor.firstValue.name()).contains("dataset-name")
+
+        val paramsCaptor = argumentCaptor<ExampleListParams>()
+        verify(exampleService, times(2)).list(paramsCaptor.capture())
+        assertThat(paramsCaptor.firstValue.dataset()).contains("dataset-id")
+    }
+
+    @Test
+    fun evaluateWithDatasetIdLoadsExamplesWithoutDatasetLookup() {
+        val datasetId = UUID.randomUUID().toString()
+        val subject = setupSubject(examplePages = listOf(listOf(example("ex-1")), emptyList()))
+
+        subject.evaluate(
+            EvaluateParams.builder().data(datasetId).target { mapOf("answer" to "4") }.build()
+        )
+
+        val paramsCaptor = argumentCaptor<ExampleListParams>()
+        verify(exampleService, times(2)).list(paramsCaptor.capture())
+        assertThat(paramsCaptor.firstValue.dataset()).contains(datasetId)
+        verify(datasetService, times(0)).list(any<DatasetListParams>())
+    }
+
+    @Test
+    fun evaluateWithMissingDatasetNameFailsBeforeLoadingExamples() {
+        val subject = setupSubject(datasetPages = listOf(emptyList()))
+
+        assertThatThrownBy {
+                subject.evaluate(
+                    EvaluateParams.builder()
+                        .data("missing-dataset")
+                        .target { mapOf("answer" to "4") }
+                        .build()
+                )
+            }
+            .isInstanceOf(IllegalArgumentException::class.java)
+            .hasMessageContaining("Dataset not found: missing-dataset")
+
+        verify(exampleService, times(0)).list(any<ExampleListParams>())
+        verify(sessionService, times(0)).create(any<SessionCreateParams>())
+    }
+
+    @Test
+    fun explicitExamplesMustBelongToOneDataset() {
+        val subject = setupSubject()
+
+        assertThatThrownBy {
+                subject.evaluate(
+                    EvaluateParams.builder()
+                        .examples(
+                            listOf(
+                                example(id = "ex-1", datasetId = "dataset-1"),
+                                example(id = "ex-2", datasetId = "dataset-2"),
+                            )
+                        )
+                        .target { mapOf("answer" to "4") }
+                        .build()
+                )
+            }
+            .isInstanceOf(IllegalArgumentException::class.java)
+            .hasMessageContaining("same dataset")
+
+        verify(sessionService, times(0)).create(any<SessionCreateParams>())
+    }
+
+    @Test
+    fun targetErrorsAreLoggedAsErroredRunsByDefault() {
+        val subject = setupSubject()
+
+        val results =
+            subject.evaluate(
+                EvaluateParams.builder()
+                    .examples(listOf(example("ex-1")))
+                    .target { error("target failed") }
+                    .addEvaluator { _, _ ->
+                        EvaluationResult.builder().key("unused").score(true).build()
+                    }
+                    .build()
+            )
+
+        assertThat(results.rows()).hasSize(1)
+        assertThat(results.rows()[0].targetError()).isPresent
+        assertThat(results.rows()[0].evaluationResults()).isEmpty()
+
+        val batchCaptor = argumentCaptor<RunIngestBatchParams>()
+        verify(runService).ingestBatch(batchCaptor.capture())
+        assertThat(
+                requireNotNull(batchCaptor.firstValue.post().getOrNull())
+                    .single()
+                    .error()
+                    .getOrNull()
+            )
+            .contains("target failed")
+        verify(feedbackService, times(0)).create(any<FeedbackCreateSchema>())
+    }
+
+    @Test
+    fun targetErrorsCanBeIgnored() {
+        val subject = setupSubject()
+
+        val results =
+            subject.evaluate(
+                EvaluateParams.builder()
+                    .examples(listOf(example("ex-1")))
+                    .target { error("target failed") }
+                    .errorHandling(ErrorHandling.IGNORE)
+                    .build()
+            )
+
+        assertThat(results.rows()).isEmpty()
+        verify(runService, times(0)).ingestBatch(any<RunIngestBatchParams>())
+        verify(feedbackService, times(0)).create(any<FeedbackCreateSchema>())
+    }
+
+    @Test
+    fun evaluatorErrorsAreCapturedAndDoNotStopOtherEvaluators() {
+        val subject = setupSubject()
+
+        val results =
+            subject.evaluate(
+                EvaluateParams.builder()
+                    .examples(listOf(example("ex-1")))
+                    .target { mapOf("answer" to "4") }
+                    .addEvaluator { _, _ -> error("evaluator failed") }
+                    .addEvaluator { _, _ ->
+                        EvaluationResult.builder().key("second").score(1.0).build()
+                    }
+                    .build()
+            )
+
+        val row = results.rows().single()
+        assertThat(row.evaluatorErrors()).hasSize(1)
+        assertThat(row.evaluatorErrors()[0].error()).hasMessageContaining("evaluator failed")
+        assertThat(row.evaluationResults().map { it.key() }).containsExactly("second")
+        assertThat(results.feedback()).hasSize(1)
+    }
+
+    @Test
+    fun sessionEndTimeIsUpdatedWhenFeedbackCreationFails() {
+        val subject = setupSubject()
+        whenever(feedbackService.create(any<FeedbackCreateSchema>()))
+            .thenThrow(RuntimeException("boom"))
+
+        assertThatThrownBy {
+                subject.evaluate(
+                    EvaluateParams.builder()
+                        .examples(listOf(example("ex-1")))
+                        .target { mapOf("answer" to "4") }
+                        .addEvaluator { _, _ ->
+                            EvaluationResult.builder().key("exact_match").score(true).build()
+                        }
+                        .build()
+                )
+            }
+            .isInstanceOf(RuntimeException::class.java)
+            .hasMessageContaining("boom")
+
+        verify(sessionService).update(any<SessionUpdateParams>())
+    }
+
+    @Test
+    fun ingestRunsInBatches() {
+        val subject = setupSubject()
+
+        subject.evaluate(
+            EvaluateParams.builder()
+                .examples(listOf(example("ex-1"), example("ex-2"), example("ex-3")))
+                .batchSize(2)
+                .target { mapOf("answer" to "4") }
+                .build()
+        )
+
+        val batchCaptor = argumentCaptor<RunIngestBatchParams>()
+        verify(runService, times(2)).ingestBatch(batchCaptor.capture())
+        assertThat(batchCaptor.allValues.map { requireNotNull(it.post().getOrNull()).size })
+            .containsExactly(2, 1)
+    }
+
+    @Test
+    fun concurrentTargetsReturnRowsInExampleOrder() {
+        val seen = ConcurrentLinkedQueue<String>()
+        val subject = setupSubject()
+
+        val results =
+            subject.evaluate(
+                EvaluateParams.builder()
+                    .examples(listOf(example("ex-1"), example("ex-2"), example("ex-3")))
+                    .maxConcurrency(3)
+                    .target { example ->
+                        seen.add(example.id())
+                        if (example.id() == "ex-1") Thread.sleep(50)
+                        mapOf("answer" to example.id())
+                    }
+                    .build()
+            )
+
+        assertThat(seen).containsExactlyInAnyOrder("ex-1", "ex-2", "ex-3")
+        assertThat(results.rows().map { it.example().id() }).containsExactly("ex-1", "ex-2", "ex-3")
+        assertThat(
+                results.rows().map {
+                    requireNotNull(it.run().outputs().getOrNull())
+                        ._additionalProperties()["answer"]
+                        ?.toPlainValue()
+                }
+            )
+            .containsExactly("ex-1", "ex-2", "ex-3")
+    }
+
+    @Test
+    fun validateRequiredParams() {
+        val subject = setupSubject()
+
+        assertThatThrownBy { EvaluateParams.builder().data("dataset").build() }
+            .isInstanceOf(IllegalArgumentException::class.java)
+            .hasMessageContaining("target")
+
+        assertThatThrownBy {
+                EvaluateParams.builder()
+                    .data("dataset")
+                    .examples(listOf(example("ex-1")))
+                    .target { emptyMap() }
+                    .build()
+            }
+            .isInstanceOf(IllegalArgumentException::class.java)
+            .hasMessageContaining("Only one")
+
+        assertThatThrownBy {
+                subject.evaluate(
+                    EvaluateParams.builder().examples(emptyList()).target { emptyMap() }.build()
+                )
+            }
+            .isInstanceOf(IllegalArgumentException::class.java)
+            .hasMessageContaining("at least one example")
+    }
+
+    private fun setupSubject(
+        examplePages: List<List<Example>> = emptyList(),
+        datasetPages: List<List<Dataset>> = emptyList(),
+    ): ExperimentClient {
+        whenever(client.datasets()).thenReturn(datasetService)
+        whenever(client.examples()).thenReturn(exampleService)
+        whenever(client.sessions()).thenReturn(sessionService)
+        whenever(client.runs()).thenReturn(runService)
+        whenever(client.feedback()).thenReturn(feedbackService)
+        whenever(sessionService.create(any<SessionCreateParams>())).thenReturn(session())
+        whenever(sessionService.update(any<SessionUpdateParams>())).thenReturn(session())
+        whenever(runService.ingestBatch(any<RunIngestBatchParams>()))
+            .thenReturn(RunIngestBatchResponse.builder().build())
+        whenever(feedbackService.create(any<FeedbackCreateSchema>())).thenAnswer { invocation ->
+            val schema = invocation.getArgument<FeedbackCreateSchema>(0)
+            FeedbackSchema.builder().id(UUID.randomUUID().toString()).key(schema.key()).build()
+        }
+
+        if (datasetPages.isNotEmpty()) {
+            val pages =
+                ArrayDeque(
+                    datasetPages.map { datasets ->
+                        DatasetListPage.builder()
+                            .service(datasetService)
+                            .params(DatasetListParams.builder().build())
+                            .items(datasets)
+                            .build()
+                    }
+                )
+            whenever(datasetService.list(any<DatasetListParams>())).thenAnswer {
+                pages.removeFirst()
+            }
+        }
+
+        if (examplePages.isNotEmpty()) {
+            val pages =
+                ArrayDeque(
+                    examplePages.map { examples ->
+                        ExampleListPage.builder()
+                            .service(exampleService)
+                            .params(ExampleListParams.builder().build())
+                            .items(examples)
+                            .build()
+                    }
+                )
+            whenever(exampleService.list(any<ExampleListParams>())).thenAnswer {
+                pages.removeFirst()
+            }
+        }
+
+        return ExperimentClient.create(client)
+    }
+
+    private fun dataset(id: String, name: String): Dataset =
+        Dataset.builder()
+            .id(id)
+            .name(name)
+            .modifiedAt(java.time.OffsetDateTime.now())
+            .sessionCount(0)
+            .tenantId("tenant-id")
+            .build()
+
+    private fun example(
+        id: String,
+        question: String = "2 + 2?",
+        answer: String = "4",
+        datasetId: String = "dataset-id",
+    ): Example =
+        Example.builder()
+            .id(id)
+            .datasetId(datasetId)
+            .name(id)
+            .inputs(
+                Example.Inputs.builder()
+                    .putAdditionalProperty("question", JsonValue.from(question))
+                    .build()
+            )
+            .outputs(
+                Example.Outputs.builder()
+                    .putAdditionalProperty("answer", JsonValue.from(answer))
+                    .build()
+            )
+            .build()
+
+    private fun session(): TracerSessionWithoutVirtualFields =
+        TracerSessionWithoutVirtualFields.builder()
+            .id("session-id")
+            .tenantId("tenant-id")
+            .name("experiment-name")
+            .referenceDatasetId("dataset-id")
+            .build()
+
+    private fun sessionMetadata(params: SessionCreateParams): Map<String, Any?> =
+        (requireNotNull(params.extra().getOrNull())
+                ._additionalProperties()["metadata"]
+                ?.toPlainValue() as? Map<*, *>)
+            .orEmpty()
+            .entries
+            .associate { (key, value) ->
+                require(key is String) { "Metadata keys must be strings" }
+                key to value
+            }
+}

--- a/langsmith-java-example/README.md
+++ b/langsmith-java-example/README.md
@@ -1,7 +1,7 @@
 # LangSmith Examples
 
 This module contains runnable Kotlin examples organized by feature:
-- **`example/`** - SDK examples (ListRuns, Dataset, PromptManagement, RecordExperiment, E2eEval)
+- **`example/`** - SDK examples (ListRuns, Dataset, PromptManagement, RecordExperiment, RunExperiment, E2eEval)
 - **`example/otel/`** - OpenTelemetry tracing examples
 
 ## Prerequisites
@@ -17,6 +17,26 @@ export LANGSMITH_API_KEY=your_api_key
 ```
 
 The `langchain.baseUrl` system property (or `LANGSMITH_ENDPOINT` environment variable) is optional and defaults to `https://api.smith.langchain.com/` if not set.
+
+## Evaluation Examples
+
+Located in `src/main/kotlin/com/langchain/smith/example/`
+
+### Run Experiment
+
+Run a high-level experiment with `ExperimentClient.evaluate`, a target function, and a local row evaluator.
+
+```bash
+./gradlew :langsmith-java-example:run -Pexample=RunExperiment \
+  -Dlangchain.langsmithApiKey=your_api_key
+```
+
+**Features demonstrated:**
+1. Create or reuse a dataset
+2. Add deterministic examples
+3. Run a target function over each example
+4. Submit exact-match evaluator feedback
+5. Print the experiment row and feedback counts
 
 ## OpenTelemetry Tracing Examples
 

--- a/langsmith-java-example/src/main/kotlin/com/langchain/smith/example/RunExperimentExample.kt
+++ b/langsmith-java-example/src/main/kotlin/com/langchain/smith/example/RunExperimentExample.kt
@@ -1,0 +1,112 @@
+package com.langchain.smith.example
+
+import com.langchain.smith.client.okhttp.LangsmithOkHttpClient
+import com.langchain.smith.core.JsonValue
+import com.langchain.smith.evaluation.EvaluateParams
+import com.langchain.smith.evaluation.EvaluationResult
+import com.langchain.smith.evaluation.ExperimentClient
+import com.langchain.smith.example.util.generateExampleId
+import com.langchain.smith.models.datasets.Dataset
+import com.langchain.smith.models.datasets.DatasetCreateParams
+import com.langchain.smith.models.datasets.DatasetListParams
+import com.langchain.smith.models.examples.bulk.BulkCreateParams
+
+/**
+ * Demonstrates running a high-level LangSmith experiment with a target function and local
+ * evaluator.
+ *
+ * ## Prerequisites
+ * Set `LANGSMITH_API_KEY` before running.
+ *
+ * ## Running
+ * ```bash
+ * ./gradlew :langsmith-java-example:run -Pexample=RunExperiment
+ * ```
+ */
+fun main() {
+    val client = LangsmithOkHttpClient.fromEnv()
+    val experimentClient = ExperimentClient.create(client)
+
+    val datasetName = "Experiment Runner Dataset - Kotlin Example"
+    val dataset = getOrCreateDataset(client, datasetName)
+    createExamples(client, dataset)
+
+    val results =
+        experimentClient.evaluate(
+            EvaluateParams.builder()
+                .data(datasetName)
+                .experimentPrefix("java-sdk-evaluate")
+                .description("High-level Java SDK experiment runner example.")
+                .putMetadata("example", "RunExperimentExample")
+                .target { example ->
+                    val question = example.inputs()["question"] as String
+                    mapOf("answer" to answer(question))
+                }
+                .addEvaluator { run, example ->
+                    val actual = run.outputs()["answer"]?.toString()
+                    val expected = example.outputs()["answer"]?.toString()
+                    val matches = actual == expected
+                    EvaluationResult.builder()
+                        .key("exact_match")
+                        .score(matches)
+                        .comment("Expected '$expected', got '$actual'.")
+                        .build()
+                }
+                .build()
+        )
+
+    println("Experiment complete: ${results.experimentName().orElse(results.experimentId())}")
+    println("Rows: ${results.rows().size}")
+    println("Feedback: ${results.feedback().size}")
+}
+
+private fun getOrCreateDataset(
+    client: com.langchain.smith.client.LangsmithClient,
+    datasetName: String,
+): Dataset {
+    val existing =
+        client.datasets().list(DatasetListParams.builder().name(datasetName).build()).items()
+    if (existing.isNotEmpty()) return existing.first()
+
+    return client
+        .datasets()
+        .create(
+            DatasetCreateParams.builder()
+                .name(datasetName)
+                .description("Dataset for the high-level Java SDK experiment runner example.")
+                .build()
+        )
+}
+
+private fun createExamples(client: com.langchain.smith.client.LangsmithClient, dataset: Dataset) {
+    val examples =
+        listOf(
+            mapOf("question" to "What is the capital of France?") to mapOf("answer" to "Paris"),
+            mapOf("question" to "What is 2 + 2?") to mapOf("answer" to "4"),
+            mapOf("question" to "Who wrote Romeo and Juliet?") to
+                mapOf("answer" to "William Shakespeare"),
+        )
+
+    val bodies =
+        examples.map { (inputs, outputs) ->
+            BulkCreateParams.Body.builder()
+                .id(generateExampleId(dataset.id(), inputs, outputs))
+                .datasetId(dataset.id())
+                .inputs(JsonValue.from(inputs))
+                .outputs(JsonValue.from(outputs))
+                .build()
+        }
+
+    client
+        .examples()
+        .bulk()
+        .create(BulkCreateParams.builder().apply { bodies.forEach { addBody(it) } }.build())
+}
+
+private fun answer(question: String): String =
+    when {
+        "capital of France" in question -> "Paris"
+        "2 + 2" in question -> "4"
+        "Romeo and Juliet" in question -> "William Shakespeare"
+        else -> "I do not know"
+    }


### PR DESCRIPTION
## Summary
- Add a synchronous high-level ExperimentClient.evaluate API for Java/Kotlin SDK users
- Add evaluation parameter/result types, local row evaluators, run ingestion, feedback creation, and session completion handling
- Add a runnable RunExperiment example and focused unit coverage

## Testing
- ./gradlew :langsmith-java-core:test --tests "com.langchain.smith.evaluation.*" --rerun
- ./gradlew :langsmith-java-core:formatKotlin
- ./gradlew lintKotlin
- ./gradlew :langsmith-java-core:test --rerun
- ./gradlew :langsmith-java-example:run -Pexample=RunExperiment