### PR TITLE
feat: Adds attachment support to Java multipart requests

### DIFF
--- a/langsmith-java-core/src/main/kotlin/com/langchain/smith/client/RunMultipartBatch.kt
+++ b/langsmith-java-core/src/main/kotlin/com/langchain/smith/client/RunMultipartBatch.kt
@@ -7,14 +7,15 @@ import com.langchain.smith.core.MultipartField
 import com.langchain.smith.core.http.HttpRequestBody
 import com.langchain.smith.core.http.multipartFormData
 import com.langchain.smith.models.runs.Run
+import com.langchain.smith.models.runs.RunAttachment
 import com.langchain.smith.models.runs.RunIngestBatchParams
 import kotlin.jvm.optionals.getOrNull
+import org.slf4j.LoggerFactory
 
 internal fun RunIngestBatchParams.toRunMultipartFormData(jsonMapper: JsonMapper): HttpRequestBody? {
     // Multipart requires run id, trace_id, and dotted_order to address each part correctly.
     // If a queued run is missing those fields, callers fall back to legacy JSON batch ingest
     // instead of failing the entire auto-batch.
-    // TODO: Add attachment parts if Java tracing starts enqueueing run attachments.
     val fields =
         listOf(
                 multipartFieldsForRuns(
@@ -62,7 +63,7 @@ private fun multipartFieldsForRun(
             .createObjectNode()
             .setAll<ObjectNode>(
                 runFields
-                    .filterNot { (fieldName, _) -> fieldName in MULTIPART_SEPARATE_FIELDS }
+                    .filterNot { (fieldName, _) -> fieldName in MULTIPART_EXCLUDED_FIELDS }
                     .toMap()
             )
     val separateFields =
@@ -77,7 +78,8 @@ private fun multipartFieldsForRun(
     return listOf("$operation.$runId" to jsonField(jsonMapper, main)) +
         separateFields.map { (fieldName, value) ->
             "$operation.$runId.$fieldName" to jsonField(jsonMapper, value)
-        }
+        } +
+        attachmentFields(runId, run.attachments())
 }
 
 private fun jsonField(jsonMapper: JsonMapper, value: JsonNode): MultipartField<ByteArray> {
@@ -88,5 +90,34 @@ private fun jsonField(jsonMapper: JsonMapper, value: JsonNode): MultipartField<B
         .build()
 }
 
+private fun attachmentFields(
+    runId: String,
+    attachments: Map<String, RunAttachment>,
+): List<Pair<String, MultipartField<*>>> =
+    attachments.mapNotNull { (name, attachment) ->
+        if (name.contains('.')) {
+            logger.warn(
+                "Skipping attachment '{}' for run {}: attachment names must not contain periods ('.')",
+                name,
+                runId,
+            )
+            return@mapNotNull null
+        }
+
+        val contentType =
+            attachment.length().getOrNull()?.let { "${attachment.contentType()}; length=$it" }
+                ?: attachment.contentType()
+        "attachment.$runId.$name" to
+            MultipartField.builder<Any>()
+                .value(attachment.multipartValue())
+                .contentType(contentType)
+                .filename(attachment.filename())
+                .build()
+    }
+
 private val MULTIPART_SEPARATE_FIELDS =
     listOf("inputs", "outputs", "events", "extra", "error", "serialized")
+
+private val MULTIPART_EXCLUDED_FIELDS = MULTIPART_SEPARATE_FIELDS + "attachments"
+
+private val logger = LoggerFactory.getLogger("com.langchain.smith.client.RunMultipartBatch")

--- a/langsmith-java-core/src/main/kotlin/com/langchain/smith/models/runs/Run.kt
+++ b/langsmith-java-core/src/main/kotlin/com/langchain/smith/models/runs/Run.kt
@@ -5,6 +5,7 @@ package com.langchain.smith.models.runs
 import com.fasterxml.jackson.annotation.JsonAnyGetter
 import com.fasterxml.jackson.annotation.JsonAnySetter
 import com.fasterxml.jackson.annotation.JsonCreator
+import com.fasterxml.jackson.annotation.JsonIgnore
 import com.fasterxml.jackson.annotation.JsonProperty
 import com.langchain.smith.core.Enum
 import com.langchain.smith.core.ExcludeMissing
@@ -43,6 +44,7 @@ private constructor(
     private val status: JsonField<String>,
     private val tags: JsonField<List<String>>,
     private val traceId: JsonField<String>,
+    private val attachments: Map<String, RunAttachment>,
     private val additionalProperties: MutableMap<String, JsonValue>,
 ) {
 
@@ -105,6 +107,7 @@ private constructor(
         status,
         tags,
         traceId,
+        emptyMap(),
         mutableMapOf(),
     )
 
@@ -401,6 +404,10 @@ private constructor(
      */
     @JsonProperty("trace_id") @ExcludeMissing fun _traceId(): JsonField<String> = traceId
 
+    /** Binary attachments to upload with this run via `/runs/multipart`. */
+    @JsonIgnore
+    fun attachments(): Map<String, RunAttachment> = Collections.unmodifiableMap(attachments)
+
     @JsonAnySetter
     private fun putAdditionalProperty(key: String, value: JsonValue) {
         additionalProperties.put(key, value)
@@ -443,6 +450,7 @@ private constructor(
         private var status: JsonField<String> = JsonMissing.of()
         private var tags: JsonField<MutableList<String>>? = null
         private var traceId: JsonField<String> = JsonMissing.of()
+        private var attachments: MutableMap<String, RunAttachment> = mutableMapOf()
         private var additionalProperties: MutableMap<String, JsonValue> = mutableMapOf()
 
         @JvmSynthetic
@@ -468,6 +476,7 @@ private constructor(
             status = run.status
             tags = run.tags.map { it.toMutableList() }
             traceId = run.traceId
+            attachments = run.attachments.toMutableMap()
             additionalProperties = run.additionalProperties.toMutableMap()
         }
 
@@ -726,6 +735,25 @@ private constructor(
          */
         fun traceId(traceId: JsonField<String>) = apply { this.traceId = traceId }
 
+        /** Binary attachments to upload with this run via `/runs/multipart`. */
+        fun attachments(attachments: Map<String, RunAttachment>) = apply {
+            this.attachments.clear()
+            putAllAttachments(attachments)
+        }
+
+        /** Adds a binary attachment to upload with this run via `/runs/multipart`. */
+        fun putAttachment(name: String, attachment: RunAttachment) = apply {
+            attachments[name] = attachment
+        }
+
+        fun putAllAttachments(attachments: Map<String, RunAttachment>) = apply {
+            this.attachments.putAll(attachments)
+        }
+
+        fun removeAttachment(name: String) = apply { attachments.remove(name) }
+
+        fun removeAllAttachments(names: Set<String>) = apply { names.forEach(::removeAttachment) }
+
         fun additionalProperties(additionalProperties: Map<String, JsonValue>) = apply {
             this.additionalProperties.clear()
             putAllAdditionalProperties(additionalProperties)
@@ -773,6 +801,7 @@ private constructor(
                 status,
                 (tags ?: JsonMissing.of()).map { it.toImmutable() },
                 traceId,
+                attachments.toImmutable(),
                 additionalProperties.toMutableMap(),
             )
     }
@@ -1802,6 +1831,7 @@ private constructor(
             status == other.status &&
             tags == other.tags &&
             traceId == other.traceId &&
+            attachments == other.attachments &&
             additionalProperties == other.additionalProperties
     }
 
@@ -1828,6 +1858,7 @@ private constructor(
             status,
             tags,
             traceId,
+            attachments,
             additionalProperties,
         )
     }
@@ -1835,5 +1866,5 @@ private constructor(
     override fun hashCode(): Int = hashCode
 
     override fun toString() =
-        "Run{id=$id, dottedOrder=$dottedOrder, endTime=$endTime, error=$error, events=$events, extra=$extra, inputAttachments=$inputAttachments, inputs=$inputs, name=$name, outputAttachments=$outputAttachments, outputs=$outputs, parentRunId=$parentRunId, referenceExampleId=$referenceExampleId, runType=$runType, serialized=$serialized, sessionId=$sessionId, sessionName=$sessionName, startTime=$startTime, status=$status, tags=$tags, traceId=$traceId, additionalProperties=$additionalProperties}"
+        "Run{id=$id, dottedOrder=$dottedOrder, endTime=$endTime, error=$error, events=$events, extra=$extra, inputAttachments=$inputAttachments, inputs=$inputs, name=$name, outputAttachments=$outputAttachments, outputs=$outputs, parentRunId=$parentRunId, referenceExampleId=$referenceExampleId, runType=$runType, serialized=$serialized, sessionId=$sessionId, sessionName=$sessionName, startTime=$startTime, status=$status, tags=$tags, traceId=$traceId, attachments=$attachments, additionalProperties=$additionalProperties}"
 }

--- a/langsmith-java-core/src/main/kotlin/com/langchain/smith/models/runs/RunAttachment.kt
+++ b/langsmith-java-core/src/main/kotlin/com/langchain/smith/models/runs/RunAttachment.kt
@@ -1,0 +1,93 @@
+package com.langchain.smith.models.runs
+
+import java.io.ByteArrayInputStream
+import java.io.InputStream
+import java.util.Optional
+
+/** Binary attachment data to send with `/runs/multipart` ingest. */
+class RunAttachment
+private constructor(
+    private val contentType: String,
+    private val data: Any,
+    private val length: Long?,
+    private val filename: String?,
+) {
+
+    fun contentType(): String = contentType
+
+    fun data(): InputStream =
+        when (val data = data) {
+            is ByteArray -> ByteArrayInputStream(data)
+            is InputStream -> data
+            else -> error("Unexpected attachment data type: ${data::class.java}")
+        }
+
+    @JvmSynthetic internal fun multipartValue(): Any = data
+
+    fun length(): Optional<Long> = Optional.ofNullable(length)
+
+    fun filename(): Optional<String> = Optional.ofNullable(filename)
+
+    fun toBuilder(): Builder = Builder().from(this)
+
+    companion object {
+
+        @JvmStatic
+        fun of(contentType: String, data: ByteArray): RunAttachment =
+            builder().contentType(contentType).data(data).build()
+
+        @JvmStatic
+        fun of(contentType: String, data: InputStream): RunAttachment =
+            builder().contentType(contentType).data(data).build()
+
+        @JvmStatic fun builder(): Builder = Builder()
+    }
+
+    class Builder internal constructor() {
+
+        private var contentType: String? = null
+        private var data: Any? = null
+        private var length: Long? = null
+        private var filename: String? = null
+
+        @JvmSynthetic
+        internal fun from(runAttachment: RunAttachment) = apply {
+            contentType = runAttachment.contentType
+            data = runAttachment.data
+            length = runAttachment.length
+            filename = runAttachment.filename
+        }
+
+        /** MIME type of the attachment, for example `text/plain` or `image/png`. */
+        fun contentType(contentType: String) = apply { this.contentType = contentType }
+
+        /** Attachment bytes. This sets [length] automatically. */
+        fun data(data: ByteArray) = apply {
+            this.data = data
+            this.length = data.size.toLong()
+        }
+
+        /** Attachment stream. Prefer [data] with bytes for repeatable requests. */
+        fun data(data: InputStream) = apply { this.data = data }
+
+        /** Attachment byte length, if known. Included in the part content type for the ingester. */
+        fun length(length: Long?) = apply { this.length = length }
+
+        /** Alias for calling [Builder.length] with `length.orElse(null)`. */
+        fun length(length: Optional<Long>) = length(length.orElse(null))
+
+        /** Optional filename directive for the multipart part. */
+        fun filename(filename: String?) = apply { this.filename = filename }
+
+        /** Alias for calling [Builder.filename] with `filename.orElse(null)`. */
+        fun filename(filename: Optional<String>) = filename(filename.orElse(null))
+
+        fun build(): RunAttachment =
+            RunAttachment(
+                checkNotNull(contentType) { "`contentType` is required but was not set" },
+                checkNotNull(data) { "`data` is required but was not set" },
+                length,
+                filename,
+            )
+    }
+}

--- a/langsmith-java-core/src/main/kotlin/com/langchain/smith/services/async/RunServiceAsync.kt
+++ b/langsmith-java-core/src/main/kotlin/com/langchain/smith/services/async/RunServiceAsync.kt
@@ -146,6 +146,41 @@ interface RunServiceAsync {
     fun ingestBatch(requestOptions: RequestOptions): CompletableFuture<RunIngestBatchResponse> =
         ingestBatch(RunIngestBatchParams.none(), requestOptions)
 
+    /**
+     * Ingests runs through `/runs/multipart`, allowing large run fields and per-run binary
+     * attachments. This mirrors the Python/JS multipart ingest shape: create runs and update runs
+     * are provided separately, and attachments are set on each [Run].
+     */
+    fun multipartIngest(): CompletableFuture<Void?> = multipartIngest(emptyList(), emptyList())
+
+    /** @see multipartIngest */
+    fun multipartIngest(
+        create: List<Run> = emptyList(),
+        update: List<Run> = emptyList(),
+        requestOptions: RequestOptions = RequestOptions.none(),
+    ): CompletableFuture<Void?>
+
+    /** @see multipartIngest */
+    fun multipartIngest(
+        create: List<Run> = emptyList(),
+        update: List<Run> = emptyList(),
+    ): CompletableFuture<Void?> = multipartIngest(create, update, RequestOptions.none())
+
+    /** @see multipartIngest */
+    fun multipartIngest(requestOptions: RequestOptions): CompletableFuture<Void?> =
+        multipartIngest(emptyList(), emptyList(), requestOptions)
+
+    /** @see multipartIngest */
+    fun multipartIngest(
+        params: RunIngestBatchParams = RunIngestBatchParams.none(),
+        requestOptions: RequestOptions = RequestOptions.none(),
+    ): CompletableFuture<Void?> =
+        multipartIngest(
+            params.post().orElse(emptyList()),
+            params.patch().orElse(emptyList()),
+            requestOptions,
+        )
+
     /** Query Runs */
     fun query(): CompletableFuture<RunQueryResponse> = query(RunQueryParams.none())
 
@@ -349,6 +384,44 @@ interface RunServiceAsync {
             requestOptions: RequestOptions
         ): CompletableFuture<HttpResponseFor<RunIngestBatchResponse>> =
             ingestBatch(RunIngestBatchParams.none(), requestOptions)
+
+        /**
+         * Returns a raw HTTP response for `post /runs/multipart`, but is otherwise the same as
+         * [RunServiceAsync.multipartIngest].
+         */
+        fun multipartIngest(): CompletableFuture<HttpResponseFor<Void?>> =
+            multipartIngest(emptyList(), emptyList())
+
+        /** @see multipartIngest */
+        fun multipartIngest(
+            create: List<Run> = emptyList(),
+            update: List<Run> = emptyList(),
+            requestOptions: RequestOptions = RequestOptions.none(),
+        ): CompletableFuture<HttpResponseFor<Void?>>
+
+        /** @see multipartIngest */
+        fun multipartIngest(
+            create: List<Run> = emptyList(),
+            update: List<Run> = emptyList(),
+        ): CompletableFuture<HttpResponseFor<Void?>> =
+            multipartIngest(create, update, RequestOptions.none())
+
+        /** @see multipartIngest */
+        fun multipartIngest(
+            requestOptions: RequestOptions
+        ): CompletableFuture<HttpResponseFor<Void?>> =
+            multipartIngest(emptyList(), emptyList(), requestOptions)
+
+        /** @see multipartIngest */
+        fun multipartIngest(
+            params: RunIngestBatchParams = RunIngestBatchParams.none(),
+            requestOptions: RequestOptions = RequestOptions.none(),
+        ): CompletableFuture<HttpResponseFor<Void?>> =
+            multipartIngest(
+                params.post().orElse(emptyList()),
+                params.patch().orElse(emptyList()),
+                requestOptions,
+            )
 
         /**
          * Returns a raw HTTP response for `post /api/v1/runs/query`, but is otherwise the same as

--- a/langsmith-java-core/src/main/kotlin/com/langchain/smith/services/async/RunServiceAsyncImpl.kt
+++ b/langsmith-java-core/src/main/kotlin/com/langchain/smith/services/async/RunServiceAsyncImpl.kt
@@ -23,6 +23,7 @@ import com.langchain.smith.core.http.zstd
 import com.langchain.smith.core.prepareAsync
 import com.langchain.smith.errors.NotFoundException
 import com.langchain.smith.models.info.InfoListResponse
+import com.langchain.smith.models.runs.Run
 import com.langchain.smith.models.runs.RunCreateParams
 import com.langchain.smith.models.runs.RunCreateResponse
 import com.langchain.smith.models.runs.RunIngestBatchParams
@@ -204,6 +205,13 @@ class RunServiceAsyncImpl internal constructor(private val clientOptions: Client
     ): CompletableFuture<RunIngestBatchResponse> =
         // post /runs/batch
         withRawResponse().ingestBatch(params, requestOptions).thenApply { it.parse() }
+
+    override fun multipartIngest(
+        create: List<Run>,
+        update: List<Run>,
+        requestOptions: RequestOptions,
+    ): CompletableFuture<Void?> =
+        withRawResponse().multipartIngest(create, update, requestOptions).thenApply { it.parse() }
 
     override fun query(
         params: RunQueryParams,
@@ -425,6 +433,31 @@ class RunServiceAsyncImpl internal constructor(private val clientOptions: Client
                 }
         }
 
+        override fun multipartIngest(
+            create: List<Run>,
+            update: List<Run>,
+            requestOptions: RequestOptions,
+        ): CompletableFuture<HttpResponseFor<Void?>> {
+            val params = RunIngestBatchParams.builder().post(create).patch(update).build()
+            val body =
+                params.toRunMultipartFormData(clientOptions.jsonMapper)
+                    ?: run {
+                        val failed = CompletableFuture<HttpResponseFor<Void?>>()
+                        failed.completeExceptionally(
+                            IllegalArgumentException(
+                                "Multipart ingest requires every run to include id, traceId, and dottedOrder"
+                            )
+                        )
+                        return failed
+                    }
+            val requestOptions = requestOptions.applyDefaults(RequestOptions.from(clientOptions))
+            return multipartRequest(params, body)
+                .thenComposeAsync { clientOptions.httpClient.executeAsync(it, requestOptions) }
+                .thenApply { response ->
+                    errorHandler.handle(response).parseable { response.use { null } }
+                }
+        }
+
         internal fun ingestMultipartBatch(
             params: RunIngestBatchParams,
             requestOptions: RequestOptions,
@@ -436,30 +469,35 @@ class RunServiceAsyncImpl internal constructor(private val clientOptions: Client
                 return CompletableFuture.completedFuture(false)
             }
             val requestOptions = requestOptions.applyDefaults(RequestOptions.from(clientOptions))
-            return zstdCompressionEnabled
-                .thenCompose { zstdCompressionEnabled ->
-                    val requestBuilder =
-                        HttpRequest.builder()
-                            .method(HttpMethod.POST)
-                            .baseUrl(clientOptions.baseUrl())
-                            .addPathSegments("runs", "multipart")
-                    if (zstdCompressionEnabled) {
-                        requestBuilder.putHeader("Content-Encoding", "zstd").body(zstd(body))
-                    } else {
-                        requestBuilder.body(body)
-                    }
-                    logger.debug(
-                        "Sending LangSmith run batch to multipart ingest endpoint (zstd compression: {})",
-                        if (zstdCompressionEnabled) "enabled" else "disabled",
-                    )
-                    requestBuilder.build().prepareAsync(clientOptions, params)
-                }
+            return multipartRequest(params, body)
                 .thenComposeAsync { clientOptions.httpClient.executeAsync(it, requestOptions) }
                 .thenApply { response ->
                     errorHandler.handle(response).use {}
                     true
                 }
         }
+
+        private fun multipartRequest(
+            params: RunIngestBatchParams,
+            body: com.langchain.smith.core.http.HttpRequestBody,
+        ): CompletableFuture<HttpRequest> =
+            zstdCompressionEnabled.thenCompose { zstdCompressionEnabled ->
+                val requestBuilder =
+                    HttpRequest.builder()
+                        .method(HttpMethod.POST)
+                        .baseUrl(clientOptions.baseUrl())
+                        .addPathSegments("runs", "multipart")
+                if (zstdCompressionEnabled) {
+                    requestBuilder.putHeader("Content-Encoding", "zstd").body(zstd(body))
+                } else {
+                    requestBuilder.body(body)
+                }
+                logger.debug(
+                    "Sending LangSmith run batch to multipart ingest endpoint (zstd compression: {})",
+                    if (zstdCompressionEnabled) "enabled" else "disabled",
+                )
+                requestBuilder.build().prepareAsync(clientOptions, params)
+            }
 
         private val queryHandler: Handler<RunQueryResponse> =
             jsonHandler<RunQueryResponse>(clientOptions.jsonMapper)

--- a/langsmith-java-core/src/main/kotlin/com/langchain/smith/services/blocking/RunService.kt
+++ b/langsmith-java-core/src/main/kotlin/com/langchain/smith/services/blocking/RunService.kt
@@ -130,6 +130,39 @@ interface RunService {
     fun ingestBatch(requestOptions: RequestOptions): RunIngestBatchResponse =
         ingestBatch(RunIngestBatchParams.none(), requestOptions)
 
+    /**
+     * Ingests runs through `/runs/multipart`, allowing large run fields and per-run binary
+     * attachments. This mirrors the Python/JS multipart ingest shape: create runs and update runs
+     * are provided separately, and attachments are set on each [Run].
+     */
+    fun multipartIngest(): Void? = multipartIngest(emptyList(), emptyList())
+
+    /** @see multipartIngest */
+    fun multipartIngest(
+        create: List<Run> = emptyList(),
+        update: List<Run> = emptyList(),
+        requestOptions: RequestOptions = RequestOptions.none(),
+    ): Void?
+
+    /** @see multipartIngest */
+    fun multipartIngest(create: List<Run> = emptyList(), update: List<Run> = emptyList()): Void? =
+        multipartIngest(create, update, RequestOptions.none())
+
+    /** @see multipartIngest */
+    fun multipartIngest(requestOptions: RequestOptions): Void? =
+        multipartIngest(emptyList(), emptyList(), requestOptions)
+
+    /** @see multipartIngest */
+    fun multipartIngest(
+        params: RunIngestBatchParams = RunIngestBatchParams.none(),
+        requestOptions: RequestOptions = RequestOptions.none(),
+    ): Void? =
+        multipartIngest(
+            params.post().orElse(emptyList()),
+            params.patch().orElse(emptyList()),
+            requestOptions,
+        )
+
     /** Query Runs */
     fun query(): RunQueryResponse = query(RunQueryParams.none())
 
@@ -338,6 +371,45 @@ interface RunService {
         @MustBeClosed
         fun ingestBatch(requestOptions: RequestOptions): HttpResponseFor<RunIngestBatchResponse> =
             ingestBatch(RunIngestBatchParams.none(), requestOptions)
+
+        /**
+         * Returns a raw HTTP response for `post /runs/multipart`, but is otherwise the same as
+         * [RunService.multipartIngest].
+         */
+        @MustBeClosed
+        fun multipartIngest(): HttpResponseFor<Void?> = multipartIngest(emptyList(), emptyList())
+
+        /** @see multipartIngest */
+        @MustBeClosed
+        fun multipartIngest(
+            create: List<Run> = emptyList(),
+            update: List<Run> = emptyList(),
+            requestOptions: RequestOptions = RequestOptions.none(),
+        ): HttpResponseFor<Void?>
+
+        /** @see multipartIngest */
+        @MustBeClosed
+        fun multipartIngest(
+            create: List<Run> = emptyList(),
+            update: List<Run> = emptyList(),
+        ): HttpResponseFor<Void?> = multipartIngest(create, update, RequestOptions.none())
+
+        /** @see multipartIngest */
+        @MustBeClosed
+        fun multipartIngest(requestOptions: RequestOptions): HttpResponseFor<Void?> =
+            multipartIngest(emptyList(), emptyList(), requestOptions)
+
+        /** @see multipartIngest */
+        @MustBeClosed
+        fun multipartIngest(
+            params: RunIngestBatchParams = RunIngestBatchParams.none(),
+            requestOptions: RequestOptions = RequestOptions.none(),
+        ): HttpResponseFor<Void?> =
+            multipartIngest(
+                params.post().orElse(emptyList()),
+                params.patch().orElse(emptyList()),
+                requestOptions,
+            )
 
         /**
          * Returns a raw HTTP response for `post /api/v1/runs/query`, but is otherwise the same as

--- a/langsmith-java-core/src/main/kotlin/com/langchain/smith/services/blocking/RunServiceImpl.kt
+++ b/langsmith-java-core/src/main/kotlin/com/langchain/smith/services/blocking/RunServiceImpl.kt
@@ -23,6 +23,7 @@ import com.langchain.smith.core.http.zstd
 import com.langchain.smith.core.prepare
 import com.langchain.smith.errors.NotFoundException
 import com.langchain.smith.models.info.InfoListResponse
+import com.langchain.smith.models.runs.Run
 import com.langchain.smith.models.runs.RunCreateParams
 import com.langchain.smith.models.runs.RunCreateResponse
 import com.langchain.smith.models.runs.RunIngestBatchParams
@@ -168,6 +169,12 @@ class RunServiceImpl internal constructor(private val clientOptions: ClientOptio
     ): RunIngestBatchResponse =
         // post /runs/batch
         withRawResponse().ingestBatch(params, requestOptions).parse()
+
+    override fun multipartIngest(
+        create: List<Run>,
+        update: List<Run>,
+        requestOptions: RequestOptions,
+    ): Void? = withRawResponse().multipartIngest(create, update, requestOptions).parse()
 
     override fun query(params: RunQueryParams, requestOptions: RequestOptions): RunQueryResponse =
         // post /api/v1/runs/query
@@ -337,6 +344,23 @@ class RunServiceImpl internal constructor(private val clientOptions: ClientOptio
             }
         }
 
+        override fun multipartIngest(
+            create: List<Run>,
+            update: List<Run>,
+            requestOptions: RequestOptions,
+        ): HttpResponseFor<Void?> {
+            val params = RunIngestBatchParams.builder().post(create).patch(update).build()
+            val body =
+                params.toRunMultipartFormData(clientOptions.jsonMapper)
+                    ?: throw IllegalArgumentException(
+                        "Multipart ingest requires every run to include id, traceId, and dottedOrder"
+                    )
+            val request = multipartRequest(params, body).prepare(clientOptions, params)
+            val requestOptions = requestOptions.applyDefaults(RequestOptions.from(clientOptions))
+            val response = clientOptions.httpClient.execute(request, requestOptions)
+            return errorHandler.handle(response).parseable { response.use { null } }
+        }
+
         internal fun ingestMultipartBatch(
             params: RunIngestBatchParams,
             requestOptions: RequestOptions,
@@ -347,6 +371,17 @@ class RunServiceImpl internal constructor(private val clientOptions: ClientOptio
                 // back to legacy JSON batch ingest for this batch only.
                 return false
             }
+            val request = multipartRequest(params, body).prepare(clientOptions, params)
+            val requestOptions = requestOptions.applyDefaults(RequestOptions.from(clientOptions))
+            val response = clientOptions.httpClient.execute(request, requestOptions)
+            errorHandler.handle(response).use {}
+            return true
+        }
+
+        private fun multipartRequest(
+            params: RunIngestBatchParams,
+            body: com.langchain.smith.core.http.HttpRequestBody,
+        ): HttpRequest {
             val requestBuilder =
                 HttpRequest.builder()
                     .method(HttpMethod.POST)
@@ -361,11 +396,7 @@ class RunServiceImpl internal constructor(private val clientOptions: ClientOptio
                 "Sending LangSmith run batch to multipart ingest endpoint (zstd compression: {})",
                 if (zstdCompressionEnabled) "enabled" else "disabled",
             )
-            val request = requestBuilder.build().prepare(clientOptions, params)
-            val requestOptions = requestOptions.applyDefaults(RequestOptions.from(clientOptions))
-            val response = clientOptions.httpClient.execute(request, requestOptions)
-            errorHandler.handle(response).use {}
-            return true
+            return requestBuilder.build()
         }
 
         private val queryHandler: Handler<RunQueryResponse> =

--- a/langsmith-java-core/src/test/kotlin/com/langchain/smith/client/RunMultipartBatchTest.kt
+++ b/langsmith-java-core/src/test/kotlin/com/langchain/smith/client/RunMultipartBatchTest.kt
@@ -3,6 +3,7 @@ package com.langchain.smith.client
 import com.langchain.smith.core.JsonValue
 import com.langchain.smith.core.jsonMapper
 import com.langchain.smith.models.runs.Run
+import com.langchain.smith.models.runs.RunAttachment
 import com.langchain.smith.models.runs.RunIngestBatchParams
 import java.io.ByteArrayOutputStream
 import org.assertj.core.api.Assertions.assertThat
@@ -97,6 +98,29 @@ internal class RunMultipartBatchTest {
         assertThat(body).doesNotContain("name=\"post.r1.error\"")
         assertThat(body).doesNotContain("name=\"post.r1.serialized\"")
         assertThat(body.multipartPayload("post.r1")).doesNotContain("null")
+    }
+
+    @Test
+    fun `serializes attachments as attachment multipart fields and omits attachments from main payload`() {
+        val run =
+            testRun("r1")
+                .toBuilder()
+                .putAttachment("foo", RunAttachment.of("text/plain", "bar".toByteArray()))
+                .putAttachment("bad.name", RunAttachment.of("text/plain", "skip".toByteArray()))
+                .build()
+        val multipart =
+            RunIngestBatchParams.builder()
+                .post(listOf(run))
+                .build()
+                .toRunMultipartFormData(jsonMapper())
+        assertThat(multipart).isNotNull()
+        val body = multipart!!.asString()
+
+        assertThat(body).contains("name=\"attachment.r1.foo\"")
+        assertThat(body).contains("Content-Type: text/plain; length=3")
+        assertThat(body.multipartPayload("attachment.r1.foo")).contains("bar")
+        assertThat(body).doesNotContain("attachment.r1.bad.name")
+        assertThat(body.multipartPayload("post.r1")).doesNotContain("attachments")
     }
 
     @Test

--- a/langsmith-java-core/src/test/kotlin/com/langchain/smith/services/blocking/RunServiceTest.kt
+++ b/langsmith-java-core/src/test/kotlin/com/langchain/smith/services/blocking/RunServiceTest.kt
@@ -24,6 +24,7 @@ import com.langchain.smith.core.http.HttpClient
 import com.langchain.smith.core.http.HttpRequest
 import com.langchain.smith.core.http.HttpResponse
 import com.langchain.smith.models.runs.Run
+import com.langchain.smith.models.runs.RunAttachment
 import com.langchain.smith.models.runs.RunIngestBatchParams
 import com.langchain.smith.models.runs.RunQueryParams
 import com.langchain.smith.models.runs.RunRetrieveParams
@@ -37,6 +38,7 @@ import java.time.OffsetDateTime
 import java.util.concurrent.CompletableFuture
 import java.util.concurrent.atomic.AtomicReference
 import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.parallel.ResourceLock
@@ -44,6 +46,47 @@ import org.junit.jupiter.api.parallel.ResourceLock
 @WireMockTest
 @ResourceLock("https://github.com/wiremock/wiremock/issues/169")
 internal class RunServiceTest {
+
+    @Test
+    fun `direct multipart ingest with input stream attachment is compressed and not retried`(
+        wmRuntimeInfo: WireMockRuntimeInfo
+    ) {
+        stubFor(
+            get(urlPathEqualTo("/info"))
+                .willReturn(okJson("""{"instance_flags":{"zstd_compression_enabled":true}}"""))
+        )
+        stubFor(post(urlPathEqualTo("/runs/multipart")).willReturn(aResponse().withStatus(503)))
+        val client =
+            LangsmithOkHttpClient.builder()
+                .apiKey("My API Key")
+                .baseUrl(wmRuntimeInfo.httpBaseUrl)
+                .build()
+        val inputStream = ByteArrayInputStream("streamed attachment".toByteArray()).buffered()
+        val run =
+            testRun("run-id")
+                .toBuilder()
+                .putAttachment(
+                    "stream",
+                    RunAttachment.builder()
+                        .contentType("text/plain")
+                        .data(inputStream)
+                        .length("streamed attachment".toByteArray().size.toLong())
+                        .build(),
+                )
+                .build()
+
+        try {
+            assertThatThrownBy { client.runs().multipartIngest(listOf(run), emptyList()) }
+
+            verify(
+                1,
+                postRequestedFor(urlPathEqualTo("/runs/multipart"))
+                    .withHeader("Content-Encoding", containing("zstd")),
+            )
+        } finally {
+            client.close()
+        }
+    }
 
     @Test
     fun `auto batch queue uses server batch ingest size limit`(wmRuntimeInfo: WireMockRuntimeInfo) {
@@ -427,6 +470,79 @@ internal class RunServiceTest {
         assertThat(body.contentType()).startsWith("multipart/form-data")
         assertThat(body.repeatable()).isTrue()
         assertThat(readBody(body)).contains("name=\"post.run-id\"")
+    }
+
+    @Test
+    fun `auto batch queue sends input stream attachment as non-repeatable compressed multipart body`() {
+        val capturedRequest = AtomicReference<HttpRequest>()
+        val httpClient = capturingHttpClient(capturedRequest)
+        val runService = autoBatchRunService(httpClient)
+        val inputStream = ByteArrayInputStream("streamed attachment".toByteArray()).buffered()
+
+        runService.create(
+            testRun("run-id")
+                .toBuilder()
+                .putAttachment(
+                    "stream",
+                    RunAttachment.builder()
+                        .contentType("text/plain")
+                        .data(inputStream)
+                        .length("streamed attachment".toByteArray().size.toLong())
+                        .build(),
+                )
+                .build()
+        )
+        runService.flush()
+
+        val request = capturedRequest.get()
+        val body = request.body!!
+        assertThat(request.pathSegments).containsExactly("runs", "multipart")
+        assertThat(request.headers.values("Content-Encoding")).containsExactly("zstd")
+        assertThat(body.contentType()).startsWith("multipart/form-data")
+        // RetryingHttpClient uses repeatable() to decide if a request can be retried. InputStream
+        // attachments are intentionally non-repeatable, and zstd preserves that signal.
+        assertThat(body.repeatable()).isFalse()
+        val decompressed = decompress(body)
+        assertThat(decompressed).contains("name=\"attachment.run-id.stream\"")
+        assertThat(decompressed).contains("Content-Type: text/plain; length=19")
+        assertThat(decompressed).contains("streamed attachment")
+    }
+
+    @Test
+    fun `direct multipart ingest sends create and update runs with per-run attachments`() {
+        val capturedRequest = AtomicReference<HttpRequest>()
+        val httpClient = capturingHttpClient(capturedRequest)
+        val runService = autoBatchRunService(httpClient)
+        val create =
+            testRun("create-id")
+                .toBuilder()
+                .putAttachment(
+                    "create-file",
+                    RunAttachment.of("text/plain", "create data".toByteArray()),
+                )
+                .build()
+        val update =
+            testRun("update-id")
+                .toBuilder()
+                .putAttachment(
+                    "update-file",
+                    RunAttachment.of("text/plain", "update data".toByteArray()),
+                )
+                .build()
+
+        runService.multipartIngest(listOf(create), listOf(update))
+
+        val request = capturedRequest.get()
+        val body = request.body!!
+        assertThat(request.pathSegments).containsExactly("runs", "multipart")
+        assertThat(request.headers.values("Content-Encoding")).containsExactly("zstd")
+        val decompressed = decompress(body)
+        assertThat(decompressed).contains("name=\"post.create-id\"")
+        assertThat(decompressed).contains("name=\"patch.update-id\"")
+        assertThat(decompressed).contains("name=\"attachment.create-id.create-file\"")
+        assertThat(decompressed).contains("name=\"attachment.update-id.update-file\"")
+        assertThat(decompressed).contains("create data")
+        assertThat(decompressed).contains("update data")
     }
 
     @Test


### PR DESCRIPTION
Adds multipart run attachment support to the Java SDK.

- Added `RunAttachment` for binary run attachments.
- Added per-run attachments on `Run`.
- Added direct multipart ingest APIs:
  - `client.runs().multipartIngest(createRuns, updateRuns)`
  - async/raw response variants
- Multipart serialization now sends:
  - run payloads as `post.{runId}` / `patch.{runId}`
  - large fields separately, e.g. `post.{runId}.inputs`
  - attachments as `attachment.{runId}.{attachmentName}`
- `InputStream` attachments are treated as non-repeatable so retry behavior is safe.

Java:
```java
import com.langchain.smith.client.okhttp.LangsmithOkHttpClient;
import com.langchain.smith.models.runs.Run;
import com.langchain.smith.models.runs.RunAttachment;

import java.nio.charset.StandardCharsets;
import java.util.List;
import java.util.UUID;

public class MultipartRunAttachmentExample {
    public static void main(String[] args) {
        var client = LangsmithOkHttpClient.builder()
            .apiKey(System.getenv("LANGSMITH_API_KEY"))
            .build();

        var runId = UUID.randomUUID().toString();

        var run = Run.builder()
            .id(runId)
            .traceId(runId)
            .dottedOrder("20250101T000000000Z" + runId)
            .name("run-with-attachment")
            .runType(Run.RunType.CHAIN)
            .putAttachment(
                "input-file",
                RunAttachment.of(
                    "text/plain",
                    "hello from an attachment".getBytes(StandardCharsets.UTF_8)
                )
            )
            .build();

        client.runs().multipartIngest(List.of(run), List.of());

        client.close();
    }
}
```

Kotlin:

```kotlin
var runId = UUID.randomUUID().toString();

var run = Run.builder()
    .id(runId)
    .traceId(runId)
    .dottedOrder("20250101T000000000Z" + runId)
    .name("run-with-attachment")
    .runType(Run.RunType.CHAIN)
    .putAttachment(
        "input-file",
        RunAttachment.of(
            "text/plain",
            "hello from an attachment".getBytes(StandardCharsets.UTF_8)
        )
    )
    .build();

client.runs().multipartIngest(List.of(run), List.of());
```