### PR TITLE
fix: harden SDK credential handling

### DIFF
--- a/langsmith-java-core/src/main/kotlin/com/langchain/smith/core/ClientOptions.kt
+++ b/langsmith-java-core/src/main/kotlin/com/langchain/smith/core/ClientOptions.kt
@@ -522,6 +522,9 @@ private constructor(
             // We replace after all the default headers to allow end-users to overwrite them.
             headers.replaceAll(this.headers.build())
             queryParams.replaceAll(this.queryParams.build())
+            if (hasAuthConfiguration()) {
+                requireSecureAuthUrl(baseUrl ?: PRODUCTION_URL, "baseUrl")
+            }
             apiKey
                 ?.takeIf { it.isNotEmpty() }
                 ?.let {
@@ -606,6 +609,13 @@ private constructor(
             return currentHeaders.values("X-API-Key").any { it.isNotBlank() } ||
                 currentHeaders.values("Authorization").any { it.isNotBlank() }
         }
+
+        private fun hasAuthConfiguration(): Boolean =
+            !apiKey.isNullOrBlank() ||
+                !oauthAccessToken.isNullOrBlank() ||
+                !tenantId.isNullOrBlank() ||
+                profileAuth != null ||
+                hasAuthHeader()
 
         private fun langsmithEndpoint(): String? =
             System.getProperty("langchain.baseUrl")

--- a/langsmith-java-core/src/main/kotlin/com/langchain/smith/core/ProfileConfig.kt
+++ b/langsmith-java-core/src/main/kotlin/com/langchain/smith/core/ProfileConfig.kt
@@ -14,6 +14,10 @@ import java.nio.charset.StandardCharsets
 import java.nio.file.Files
 import java.nio.file.Path
 import java.nio.file.Paths
+import java.nio.file.StandardCopyOption
+import java.nio.file.StandardOpenOption
+import java.nio.file.attribute.PosixFilePermission
+import java.nio.file.attribute.PosixFilePermissions
 import java.time.Clock
 import java.time.Duration
 import java.time.Instant
@@ -100,9 +104,13 @@ private fun refreshProfileOAuthToken(
     refreshToken: String,
 ): OAuthTokenResponse? {
     return runCatching {
+            val tokenEndpoint =
+                requireSecureAuthUrl(
+                    "${normalizeConfigUrl(baseUrl)}/oauth/token",
+                    "OAuth token endpoint",
+                )
             val connection =
-                (URL("${normalizeConfigUrl(baseUrl)}/oauth/token").openConnection()
-                        as HttpURLConnection)
+                (URL(tokenEndpoint).openConnection() as HttpURLConnection)
                     .apply {
                         requestMethod = "POST"
                         connectTimeout = TOKEN_REFRESH_TIMEOUT.toMillis().toInt()
@@ -159,6 +167,63 @@ private fun expiresAt(node: JsonNode?): Instant? =
     }
 
 private fun String.trimQuotes(): String = trim().trim('"', '\'')
+
+private val CREDENTIAL_DIRECTORY_PERMISSIONS: Set<PosixFilePermission> =
+    PosixFilePermissions.fromString("rwx------")
+
+private val CREDENTIAL_FILE_PERMISSIONS: Set<PosixFilePermission> =
+    PosixFilePermissions.fromString("rw-------")
+
+private fun createCredentialDirectory(path: Path) {
+    if (supportsPosix(path.toAbsolutePath().parent ?: path)) {
+        Files.createDirectories(
+            path,
+            PosixFilePermissions.asFileAttribute(CREDENTIAL_DIRECTORY_PERMISSIONS),
+        )
+    } else {
+        Files.createDirectories(path)
+    }
+    setPosixPermissionsIfSupported(path, CREDENTIAL_DIRECTORY_PERMISSIONS)
+}
+
+private fun createCredentialTempFile(parent: Path): Path =
+    if (supportsPosix(parent)) {
+        Files.createTempFile(
+            parent,
+            "config",
+            ".json.tmp",
+            PosixFilePermissions.asFileAttribute(CREDENTIAL_FILE_PERMISSIONS),
+        )
+    } else {
+        Files.createTempFile(parent, "config", ".json.tmp")
+    }
+
+private fun setCredentialFilePermissions(path: Path) {
+    setPosixPermissionsIfSupported(path, CREDENTIAL_FILE_PERMISSIONS)
+}
+
+private fun moveCredentialFile(source: Path, target: Path) {
+    runCatching {
+            Files.move(
+                source,
+                target,
+                StandardCopyOption.ATOMIC_MOVE,
+                StandardCopyOption.REPLACE_EXISTING,
+            )
+        }
+        .getOrElse {
+            Files.move(source, target, StandardCopyOption.REPLACE_EXISTING)
+        }
+}
+
+private fun setPosixPermissionsIfSupported(path: Path, permissions: Set<PosixFilePermission>) {
+    if (supportsPosix(path)) {
+        Files.setPosixFilePermissions(path, permissions)
+    }
+}
+
+private fun supportsPosix(path: Path): Boolean =
+    runCatching { Files.getFileStore(path).supportsFileAttributeView("posix") }.getOrDefault(false)
 
 internal class ProfileAuth(
     private val jsonMapper: JsonMapper,
@@ -224,8 +289,25 @@ internal class ProfileAuth(
 
     private fun saveConfig() {
         runCatching {
-            configPath.parent?.let { Files.createDirectories(it) }
-            jsonMapper.writerWithDefaultPrettyPrinter().writeValue(configPath.toFile(), config)
+            val targetPath = configPath.toAbsolutePath()
+            val parent = targetPath.parent
+            parent?.let { createCredentialDirectory(it) }
+            val tempFile =
+                if (parent != null) createCredentialTempFile(parent)
+                else Files.createTempFile("config", ".json.tmp")
+            try {
+                Files.newOutputStream(
+                        tempFile,
+                        StandardOpenOption.WRITE,
+                        StandardOpenOption.TRUNCATE_EXISTING,
+                    )
+                    .use { jsonMapper.writerWithDefaultPrettyPrinter().writeValue(it, config) }
+                setCredentialFilePermissions(tempFile)
+                moveCredentialFile(tempFile, targetPath)
+                setCredentialFilePermissions(targetPath)
+            } finally {
+                Files.deleteIfExists(tempFile)
+            }
         }
     }
 }

--- a/langsmith-java-core/src/main/kotlin/com/langchain/smith/core/UrlSecurity.kt
+++ b/langsmith-java-core/src/main/kotlin/com/langchain/smith/core/UrlSecurity.kt
@@ -1,0 +1,27 @@
+package com.langchain.smith.core
+
+import java.net.URI
+
+internal fun requireSecureAuthUrl(url: String, description: String): String =
+    url.also {
+        require(isSecureAuthUrl(it)) {
+            "$description must use https when sending credentials; http is only allowed for localhost."
+        }
+    }
+
+internal fun isSecureAuthUrl(url: String): Boolean =
+    runCatching {
+            val uri = URI(url)
+            when {
+                uri.scheme.equals("https", ignoreCase = true) -> true
+                uri.scheme.equals("http", ignoreCase = true) && uri.isLoopbackHost() -> true
+                else -> false
+            }
+        }
+        .getOrDefault(false)
+
+private fun URI.isLoopbackHost(): Boolean {
+    val normalizedHost = host?.trimEnd('.')?.lowercase() ?: return false
+    return normalizedHost == "localhost" || normalizedHost == "127.0.0.1" || normalizedHost == "::1" ||
+        normalizedHost == "[::1]"
+}

--- a/langsmith-java-core/src/main/kotlin/com/langchain/smith/core/handlers/ErrorHandler.kt
+++ b/langsmith-java-core/src/main/kotlin/com/langchain/smith/core/handlers/ErrorHandler.kt
@@ -35,50 +35,38 @@ internal fun errorBodyHandler(jsonMapper: JsonMapper): Handler<JsonValue> {
 @JvmSynthetic
 internal fun errorHandler(errorBodyHandler: Handler<JsonValue>): Handler<HttpResponse> =
     object : Handler<HttpResponse> {
-        override fun handle(response: HttpResponse): HttpResponse =
-            when (val statusCode = response.statusCode()) {
-                in 200..299 -> response
-                400 ->
-                    throw BadRequestException.builder()
-                        .headers(response.headers())
-                        .body(errorBodyHandler.handle(response))
-                        .build()
-                401 ->
-                    throw UnauthorizedException.builder()
-                        .headers(response.headers())
-                        .body(errorBodyHandler.handle(response))
-                        .build()
-                403 ->
-                    throw PermissionDeniedException.builder()
-                        .headers(response.headers())
-                        .body(errorBodyHandler.handle(response))
-                        .build()
-                404 ->
-                    throw NotFoundException.builder()
-                        .headers(response.headers())
-                        .body(errorBodyHandler.handle(response))
-                        .build()
-                422 ->
-                    throw UnprocessableEntityException.builder()
-                        .headers(response.headers())
-                        .body(errorBodyHandler.handle(response))
-                        .build()
-                429 ->
-                    throw RateLimitException.builder()
-                        .headers(response.headers())
-                        .body(errorBodyHandler.handle(response))
-                        .build()
+        override fun handle(response: HttpResponse): HttpResponse {
+            val statusCode = response.statusCode()
+            if (statusCode in 200..299) {
+                return response
+            }
+
+            val headers = response.headers()
+            val body = try {
+                errorBodyHandler.handle(response)
+            } finally {
+                response.close()
+            }
+
+            throw when (statusCode) {
+                400 -> BadRequestException.builder().headers(headers).body(body).build()
+                401 -> UnauthorizedException.builder().headers(headers).body(body).build()
+                403 -> PermissionDeniedException.builder().headers(headers).body(body).build()
+                404 -> NotFoundException.builder().headers(headers).body(body).build()
+                422 -> UnprocessableEntityException.builder().headers(headers).body(body).build()
+                429 -> RateLimitException.builder().headers(headers).body(body).build()
                 in 500..599 ->
-                    throw InternalServerException.builder()
+                    InternalServerException.builder()
                         .statusCode(statusCode)
-                        .headers(response.headers())
-                        .body(errorBodyHandler.handle(response))
+                        .headers(headers)
+                        .body(body)
                         .build()
                 else ->
-                    throw UnexpectedStatusCodeException.builder()
+                    UnexpectedStatusCodeException.builder()
                         .statusCode(statusCode)
-                        .headers(response.headers())
-                        .body(errorBodyHandler.handle(response))
+                        .headers(headers)
+                        .body(body)
                         .build()
             }
+        }
     }

--- a/langsmith-java-core/src/main/kotlin/com/langchain/smith/core/http/LoggingHttpClient.kt
+++ b/langsmith-java-core/src/main/kotlin/com/langchain/smith/core/http/LoggingHttpClient.kt
@@ -167,7 +167,7 @@ private constructor(
     private fun logHeaders(headers: Headers) =
         headers.names().forEach { name ->
             headers.values(name).forEach { value ->
-                System.err.println("$name: ${if (redactedHeaders.contains(name)) "██" else value}")
+                System.err.println("$name: ${if (isSensitiveHeader(name, redactedHeaders)) "██" else value}")
             }
         }
 
@@ -193,8 +193,7 @@ private constructor(
     class Builder internal constructor() {
 
         private var httpClient: HttpClient? = null
-        private var redactedHeaders: Set<String> =
-            setOf("authorization", "api-key", "x-api-key", "cookie", "set-cookie", "x-tenant-id")
+        private var redactedHeaders: Set<String> = DEFAULT_REDACTED_HEADERS
         private var clock: Clock = Clock.systemUTC()
         private var level: LogLevel? = null
 

--- a/langsmith-java-core/src/main/kotlin/com/langchain/smith/core/http/SensitiveHeaders.kt
+++ b/langsmith-java-core/src/main/kotlin/com/langchain/smith/core/http/SensitiveHeaders.kt
@@ -1,0 +1,7 @@
+package com.langchain.smith.core.http
+
+internal val DEFAULT_REDACTED_HEADERS: Set<String> =
+    setOf("authorization", "api-key", "x-api-key", "cookie", "set-cookie", "x-tenant-id")
+
+internal fun isSensitiveHeader(name: String, redactedHeaders: Set<String> = DEFAULT_REDACTED_HEADERS): Boolean =
+    redactedHeaders.any { it.equals(name, ignoreCase = true) }

--- a/langsmith-java-core/src/main/kotlin/com/langchain/smith/errors/LangChainServiceException.kt
+++ b/langsmith-java-core/src/main/kotlin/com/langchain/smith/errors/LangChainServiceException.kt
@@ -2,7 +2,6 @@
 
 package com.langchain.smith.errors
 
-import com.fasterxml.jackson.databind.ObjectMapper
 import com.langchain.smith.core.JsonValue
 import com.langchain.smith.core.http.Headers
 
@@ -18,16 +17,10 @@ protected constructor(message: String, cause: Throwable? = null) :
 
     companion object {
 
-        /** Formats a status code and [JsonValue] error body into an error message. */
+        /** Formats a status code and [JsonValue] error body into a redacted error message. */
+        @Suppress("UNUSED_PARAMETER")
         @JvmStatic
-        fun formatMessage(statusCode: Int, body: JsonValue): String {
-            val bodyStr =
-                try {
-                    ObjectMapper().writeValueAsString(body)
-                } catch (_: Exception) {
-                    body.toString()
-                }
-            return "$statusCode: $bodyStr"
-        }
+        fun formatMessage(statusCode: Int, body: JsonValue): String =
+            "$statusCode: response body redacted; inspect body() for details"
     }
 }

--- a/langsmith-java-core/src/main/kotlin/com/langchain/smith/otel/OtelTraceExporter.kt
+++ b/langsmith-java-core/src/main/kotlin/com/langchain/smith/otel/OtelTraceExporter.kt
@@ -1,5 +1,6 @@
 package com.langchain.smith.otel
 
+import com.langchain.smith.core.http.isSensitiveHeader
 import io.opentelemetry.api.OpenTelemetry
 import io.opentelemetry.api.trace.Tracer
 import io.opentelemetry.exporter.otlp.http.trace.OtlpHttpSpanExporter
@@ -12,6 +13,9 @@ import io.opentelemetry.semconv.ServiceAttributes
 import java.time.Duration
 import java.util.concurrent.TimeUnit
 import org.slf4j.LoggerFactory
+
+internal fun redactHeadersForLogging(headers: Map<String, String>): Map<String, String> =
+    headers.mapValues { (name, value) -> if (isSensitiveHeader(name)) "[REDACTED]" else value }
 
 /**
  * Manages OpenTelemetry SDK for exporting traces to OTLP endpoints.
@@ -89,7 +93,7 @@ private constructor(
                 config.endpoint,
                 config.timeout,
             )
-            logger.debug("Headers: {}", config.headers)
+            logger.debug("Headers: {}", redactHeadersForLogging(config.headers))
             logger.debug("Service name: {}, Project name: {}", serviceName, projectName)
 
             return OtelTraceExporter(config, openTelemetry, tracer, tracerProvider, projectName)

--- a/langsmith-java-core/src/test/kotlin/com/langchain/smith/core/ClientOptionsTest.kt
+++ b/langsmith-java-core/src/test/kotlin/com/langchain/smith/core/ClientOptionsTest.kt
@@ -4,6 +4,7 @@ package com.langchain.smith.core
 
 import com.langchain.smith.core.http.HttpClient
 import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 import org.mockito.junit.jupiter.MockitoExtension
@@ -41,6 +42,31 @@ internal class ClientOptionsTest {
         clientOptions = clientOptions.toBuilder().apiKey("another My API Key").build()
 
         assertThat(clientOptions.headers.values("X-API-Key")).containsExactly("another My API Key")
+    }
+
+    @Test
+    fun buildRejectsNonLocalHttpBaseUrlWhenSendingCredentials() {
+        assertThatThrownBy {
+                ClientOptions.builder()
+                    .httpClient(httpClient)
+                    .baseUrl("http://example.com")
+                    .apiKey("My API Key")
+                    .build()
+            }
+            .isInstanceOf(IllegalArgumentException::class.java)
+            .hasMessageContaining("baseUrl must use https")
+    }
+
+    @Test
+    fun buildAllowsLocalHttpBaseUrlWhenSendingCredentials() {
+        val clientOptions =
+            ClientOptions.builder()
+                .httpClient(httpClient)
+                .baseUrl("http://127.0.0.1:8080")
+                .apiKey("My API Key")
+                .build()
+
+        assertThat(clientOptions.baseUrl()).isEqualTo("http://127.0.0.1:8080")
     }
 
     @Test

--- a/langsmith-java-core/src/test/kotlin/com/langchain/smith/core/ProfileConfigTest.kt
+++ b/langsmith-java-core/src/test/kotlin/com/langchain/smith/core/ProfileConfigTest.kt
@@ -12,11 +12,13 @@ import java.net.InetSocketAddress
 import java.nio.charset.StandardCharsets
 import java.nio.file.Files
 import java.nio.file.Path
+import java.nio.file.attribute.PosixFilePermissions
 import java.time.Clock
 import java.time.Instant
 import java.time.ZoneOffset
 import java.util.concurrent.CompletableFuture
 import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Assumptions.assumeTrue
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.io.TempDir
 
@@ -196,6 +198,103 @@ internal class ProfileConfigTest {
 
             assertThat(capturedAuthHeaders)
                 .containsExactly("Bearer new-access-token", "Bearer new-access-token")
+        } finally {
+            server.stop(0)
+        }
+    }
+
+    @Test
+    fun profileAuthDoesNotRefreshOauthTokenOverNonLocalHttp() {
+        val configPath =
+            writeConfig(
+                """
+                {
+                  "profiles": {
+                    "default": {
+                      "api_url": "http://example.com/api/v1/",
+                      "oauth": {
+                        "access_token": "old-access-token",
+                        "refresh_token": "old-refresh-token",
+                        "expires_at": "2000-01-01T00:00:00Z"
+                      }
+                    }
+                  }
+                }
+                """
+                    .trimIndent()
+            )
+
+        val config =
+            loadProfileClientConfig(
+                jsonMapper = jsonMapper(),
+                clock = clock,
+                configPathOverride = configPath,
+            )
+
+        assertThat(config?.profileAuth?.authHeader())
+            .isEqualTo("Authorization" to "Bearer old-access-token")
+        assertThat(String(Files.readAllBytes(configPath), StandardCharsets.UTF_8))
+            .contains("old-refresh-token")
+            .doesNotContain("new-access-token")
+    }
+
+    @Test
+    fun profileAuthWritesConfigWithOwnerOnlyPosixPermissions() {
+        assumeTrue(Files.getFileStore(tempDir).supportsFileAttributeView("posix"))
+        val server = HttpServer.create(InetSocketAddress("127.0.0.1", 0), 0)
+        server.createContext("/oauth/token") { exchange ->
+            exchange.requestBody.close()
+            val response =
+                """
+                {
+                  "access_token": "new-access-token",
+                  "refresh_token": "new-refresh-token",
+                  "expires_in": 3600
+                }
+                """
+                    .trimIndent()
+                    .toByteArray(StandardCharsets.UTF_8)
+            exchange.responseHeaders.add("Content-Type", "application/json")
+            exchange.sendResponseHeaders(200, response.size.toLong())
+            exchange.responseBody.use { it.write(response) }
+        }
+        server.start()
+        try {
+            val configPath = tempDir.resolve(".langsmith").resolve("config.json")
+            Files.createDirectories(configPath.parent)
+            Files.write(
+                configPath,
+                """
+                {
+                  "profiles": {
+                    "default": {
+                      "api_url": "http://127.0.0.1:${server.address.port}/api/v1/",
+                      "oauth": {
+                        "access_token": "old-access-token",
+                        "refresh_token": "old-refresh-token",
+                        "expires_at": "2000-01-01T00:00:00Z"
+                      }
+                    }
+                  }
+                }
+                """
+                    .trimIndent()
+                    .toByteArray(StandardCharsets.UTF_8),
+            )
+
+            val config =
+                loadProfileClientConfig(
+                    jsonMapper = jsonMapper(),
+                    clock = clock,
+                    configPathOverride = configPath,
+                )
+
+            assertThat(config?.profileAuth?.authHeader())
+                .isEqualTo("Authorization" to "Bearer new-access-token")
+            assertThat(Files.getPosixFilePermissions(configPath))
+                .isEqualTo(PosixFilePermissions.fromString("rw-------"))
+            assertThat(Files.getPosixFilePermissions(configPath.parent))
+                .isEqualTo(PosixFilePermissions.fromString("rwx------"))
         } finally {
             server.stop(0)
         }

--- a/langsmith-java-core/src/test/kotlin/com/langchain/smith/core/handlers/ErrorHandlerTest.kt
+++ b/langsmith-java-core/src/test/kotlin/com/langchain/smith/core/handlers/ErrorHandlerTest.kt
@@ -1,0 +1,54 @@
+package com.langchain.smith.core.handlers
+
+import com.langchain.smith.core.JsonValue
+import com.langchain.smith.core.http.Headers
+import com.langchain.smith.core.http.HttpResponse
+import com.langchain.smith.errors.BadRequestException
+import java.io.ByteArrayInputStream
+import java.io.InputStream
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+
+internal class ErrorHandlerTest {
+
+    @Test
+    fun errorHandlerClosesNonSuccessfulResponseBeforeThrowing() {
+        val response = TestHttpResponse(statusCode = 400)
+        val handler = errorHandler(testErrorBodyHandler())
+
+        val exception = assertThrows<BadRequestException> { handler.handle(response) }
+
+        assertThat(exception.statusCode()).isEqualTo(400)
+        assertThat(response.closed).isTrue()
+    }
+
+    @Test
+    fun errorHandlerLeavesSuccessfulResponseOpenForCaller() {
+        val response = TestHttpResponse(statusCode = 200)
+        val handler = errorHandler(testErrorBodyHandler())
+
+        assertThat(handler.handle(response)).isSameAs(response)
+        assertThat(response.closed).isFalse()
+    }
+
+    private fun testErrorBodyHandler(): HttpResponse.Handler<JsonValue> =
+        object : HttpResponse.Handler<JsonValue> {
+            override fun handle(response: HttpResponse): JsonValue = JsonValue.from(mapOf("error" to "bad"))
+        }
+
+    private class TestHttpResponse(private val statusCode: Int) : HttpResponse {
+        var closed = false
+            private set
+
+        override fun statusCode(): Int = statusCode
+
+        override fun headers(): Headers = Headers.builder().build()
+
+        override fun body(): InputStream = ByteArrayInputStream(ByteArray(0))
+
+        override fun close() {
+            closed = true
+        }
+    }
+}

--- a/langsmith-java-core/src/test/kotlin/com/langchain/smith/errors/ServiceExceptionErrorMessageTest.kt
+++ b/langsmith-java-core/src/test/kotlin/com/langchain/smith/errors/ServiceExceptionErrorMessageTest.kt
@@ -1,64 +1,20 @@
 package com.langchain.smith.errors
 
-import com.langchain.smith.client.okhttp.LangsmithOkHttpClient
-import com.langchain.smith.models.runs.RunIngest
-import com.langchain.smith.models.runs.RunIngestBatchParams
+import com.langchain.smith.core.JsonValue
+import com.langchain.smith.core.http.Headers
 import org.assertj.core.api.Assertions.assertThat
-import org.assertj.core.api.Assertions.assertThatThrownBy
-import org.junit.jupiter.api.Assumptions.assumeTrue
 import org.junit.jupiter.api.Test
 
-/**
- * Verifies that service exception error messages contain the actual API error body rather than
- * opaque strings like `[object Object]`.
- *
- * Run with:
- * ```bash
- * ./gradlew :langsmith-java-core:test --tests "com.langchain.smith.errors.ServiceExceptionErrorMessageTest"
- * ```
- */
 internal class ServiceExceptionErrorMessageTest {
 
     @Test
-    fun forbiddenErrorContainsDetail() {
-        val client = LangsmithOkHttpClient.builder().apiKey("ls-invalid-key").build()
+    fun serviceExceptionMessageRedactsResponseBody() {
+        val body = JsonValue.from(mapOf("detail" to "secret response detail"))
 
-        assertThatThrownBy { client.runs().ingestBatch() }
-            .isInstanceOf(PermissionDeniedException::class.java)
-            .satisfies({ e ->
-                val message = e.message ?: ""
-                assertThat(message).startsWith("403:")
-                assertThat(message).doesNotContain("[object Object]")
-                assertThat(message).contains("Forbidden")
-            })
-    }
+        val exception = BadRequestException.builder().headers(Headers.builder().build()).body(body).build()
 
-    @Test
-    fun badRequestErrorContainsDetail() {
-        assumeTrue(
-            !System.getenv("LANGSMITH_API_KEY").isNullOrBlank(),
-            "Skipping: LANGSMITH_API_KEY must be set",
-        )
-        val client = LangsmithOkHttpClient.fromEnv()
-
-        val params =
-            RunIngestBatchParams.builder()
-                .addPost(
-                    RunIngest.builder()
-                        .id("not-a-uuid")
-                        .name("test")
-                        .runType(RunIngest.RunType.CHAIN)
-                        .build()
-                )
-                .build()
-
-        assertThatThrownBy { client.runs().ingestBatch(params) }
-            .isInstanceOf(UnprocessableEntityException::class.java)
-            .satisfies({ e ->
-                val message = e.message ?: ""
-                assertThat(message).startsWith("422:")
-                assertThat(message).doesNotContain("[object Object]")
-                assertThat(message).contains("error")
-            })
+        assertThat(exception.message).isEqualTo("400: response body redacted; inspect body() for details")
+        assertThat(exception.message).doesNotContain("secret response detail")
+        assertThat(exception.body()).isEqualTo(body)
     }
 }

--- a/langsmith-java-core/src/test/kotlin/com/langchain/smith/otel/OtelTraceExporterTest.kt
+++ b/langsmith-java-core/src/test/kotlin/com/langchain/smith/otel/OtelTraceExporterTest.kt
@@ -1,0 +1,25 @@
+package com.langchain.smith.otel
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+internal class OtelTraceExporterTest {
+
+    @Test
+    fun redactHeadersForLoggingRedactsSensitiveHeaderValuesCaseInsensitively() {
+        val redacted =
+            redactHeadersForLogging(
+                mapOf(
+                    "x-api-key" to "secret-api-key",
+                    "Authorization" to "Bearer secret-token",
+                    "Langsmith-Project" to "project-name",
+                )
+            )
+
+        assertThat(redacted)
+            .containsEntry("x-api-key", "[REDACTED]")
+            .containsEntry("Authorization", "[REDACTED]")
+            .containsEntry("Langsmith-Project", "project-name")
+        assertThat(redacted.values).doesNotContain("secret-api-key", "Bearer secret-token")
+    }
+}


### PR DESCRIPTION
## Summary
- enforce HTTPS for auth-bearing base URLs and OAuth token refresh endpoints, while preserving localhost HTTP for local development/tests
- redact sensitive OTLP/debug headers and service exception messages, while preserving structured error bodies via `body()`
- write profile config updates through owner-only credential files and close non-2xx responses when error handling throws

## Corridor findings addressed
- 1cbaae85-770a-4475-9012-d9c742b9cf28
- ceaa89b3-ee4b-41c8-93e6-af46f22dfd9b
- 2abefa45-4ca8-4e5a-baa9-11edbd25e487
- 8522f915-ff3f-4d2e-bb7f-597bcd18a4a8
- eea8d917-7abf-4d9a-827d-d18b338cb74e

## Validation
- `git diff --cached --check`
- Gradle formatting/tests not run locally: the sandbox could not download the Gradle 9.5.0 distribution from `services.gradle.org` / GitHub releases (502/proxy callback response). CI should run the full Gradle checks on the PR.
