### PR TITLE
fix(evaluation): don't post comparative feedback without a session_id

### DIFF
--- a/langsmith-java-core/src/main/kotlin/com/langchain/smith/evaluation/EvaluateSupport.kt
+++ b/langsmith-java-core/src/main/kotlin/com/langchain/smith/evaluation/EvaluateSupport.kt
@@ -12,7 +12,10 @@ import com.langchain.smith.models.runs.RunQueryParams
 import com.langchain.smith.models.runs.RunSchema
 import com.langchain.smith.models.sessions.TracerSession
 import java.util.UUID
+import java.util.logging.Logger
 import kotlin.jvm.optionals.getOrNull
+
+private val logger = Logger.getLogger("com.langchain.smith.evaluation.EvaluateSupport")
 
 internal fun expandExamples(examples: List<Example>, numRepetitions: Int): List<Example> =
     if (numRepetitions <= 1) {
@@ -183,25 +186,38 @@ internal fun logComparativeEvaluationFeedback(
         }
     val runsById = runs.associateBy { it.id().getOrNull().orEmpty() }
     for ((runId, score) in result.scores) {
+        // Score-map keys come from the evaluator; a run outside the comparison has no session.
         val run = runsById[runId]
+        val sessionId = run?.sessionId()?.getOrNull()
+        if (run == null || sessionId == null) {
+            logger.warning(
+                "Skipping comparative feedback '${forLog(result.key)}' for run " +
+                    "${forLog(runId)}: it is not one of the ${runsById.size} runs being " +
+                    "compared, so its session is unknown."
+            )
+            continue
+        }
         val builder =
             FeedbackCreateSchema.builder()
                 .key(result.key)
                 .runId(runId)
                 .score(score.toDouble())
+                .sessionId(sessionId)
                 .comparativeExperimentId(comparativeExperimentId)
                 .feedbackGroupId(feedbackGroupId)
                 .feedbackSource(
                     ModelFeedbackSource.builder().type(ModelFeedbackSource.Type.MODEL).build()
                 )
         comments[runId]?.let { builder.comment(it) }
-        run?.sessionId()?.getOrNull()?.let { builder.sessionId(it) }
-        run?.startTime()?.getOrNull()?.let { startTime ->
+        run.startTime().getOrNull()?.let { startTime ->
             runStartTime(startTime)?.let { builder.startTime(it) }
         }
         client.feedback().create(builder.build())
     }
 }
+
+/** Strips control characters and caps length so log records cannot be forged. */
+private fun forLog(value: String): String = value.filterNot { it.isISOControl() }.take(100)
 
 private fun buildProjectFeedbackCreateSchema(
     result: EvaluationResult,

--- a/langsmith-java-core/src/test/kotlin/com/langchain/smith/evaluation/EvaluateSupportTest.kt
+++ b/langsmith-java-core/src/test/kotlin/com/langchain/smith/evaluation/EvaluateSupportTest.kt
@@ -1,0 +1,79 @@
+package com.langchain.smith.evaluation
+
+import com.langchain.smith.client.LangsmithClient
+import com.langchain.smith.models.feedback.FeedbackCreateSchema
+import com.langchain.smith.models.feedback.FeedbackSchema
+import com.langchain.smith.models.runs.RunIngest
+import com.langchain.smith.services.blocking.FeedbackService
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.argumentCaptor
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.times
+import org.mockito.kotlin.verify
+
+internal class EvaluateSupportTest {
+
+    private val runIdA = "11111111-1111-1111-1111-111111111111"
+    private val runIdB = "22222222-2222-2222-2222-222222222222"
+    private val sessionIdA = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"
+    private val sessionIdB = "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb"
+    private val comparativeExperimentId = "33333333-3333-3333-3333-333333333333"
+    private val feedbackGroupId = "44444444-4444-4444-4444-444444444444"
+
+    // JUnit 5 builds a fresh instance per test method, so these are per-test mocks.
+    private val feedbackService =
+        mock<FeedbackService> {
+            on { create(any<FeedbackCreateSchema>()) } doReturn
+                FeedbackSchema.builder().id("feedback-id").key("preference").build()
+        }
+    private val client = mock<LangsmithClient> { on { feedback() } doReturn feedbackService }
+
+    @Test
+    fun comparativeFeedback_postsSessionIdForEachComparedRun() {
+        logComparativeEvaluationFeedback(
+            client,
+            ComparisonEvaluationResult(
+                key = "preference",
+                scores = mapOf(runIdA to 1, runIdB to 0),
+                comment = "A is better",
+            ),
+            listOf(run(runIdA, sessionIdA), run(runIdB, sessionIdB)),
+            comparativeExperimentId,
+            feedbackGroupId,
+        )
+
+        val captor = argumentCaptor<FeedbackCreateSchema>()
+        verify(feedbackService, times(2)).create(captor.capture())
+        assertThat(captor.firstValue.runId()).contains(runIdA)
+        assertThat(captor.firstValue.sessionId()).contains(sessionIdA)
+        assertThat(captor.secondValue.runId()).contains(runIdB)
+        assertThat(captor.secondValue.sessionId()).contains(sessionIdB)
+    }
+
+    @Test
+    fun comparativeFeedback_skipsRunsNotBeingCompared() {
+        logComparativeEvaluationFeedback(
+            client,
+            ComparisonEvaluationResult(
+                key = "preference",
+                // A run the evaluator was never given — a nested run, or an id an LLM judge
+                // invented. It has no session, so it must not be posted.
+                scores = mapOf(runIdA to 1, "99999999-9999-9999-9999-999999999999" to 0),
+            ),
+            listOf(run(runIdA, sessionIdA)),
+            comparativeExperimentId,
+            feedbackGroupId,
+        )
+
+        val captor = argumentCaptor<FeedbackCreateSchema>()
+        verify(feedbackService, times(1)).create(captor.capture())
+        assertThat(captor.firstValue.runId()).contains(runIdA)
+        assertThat(captor.firstValue.sessionId()).contains(sessionIdA)
+    }
+
+    private fun run(runId: String, sessionId: String): RunIngest =
+        RunIngest.builder().id(runId).sessionId(sessionId).build()
+}


### PR DESCRIPTION
`logComparativeEvaluationFeedback` looked each run up by the keys of the score map
returned by the user's comparative evaluator, but posted the feedback whether or not
the lookup hit. On a miss, `POST /api/v1/feedback` went out with a `run_id` but no
`session_id` — while still carrying this comparison's `comparative_experiment_id` and
`feedback_group_id`. `ComparisonEvaluationResult.scores` is authored entirely by the
evaluator and was never checked against the runs it was handed, so a nested run id, or
one an LLM judge invented, was enough to trigger it.

Such an entry is now skipped with a `WARNING`, and `.sessionId(...)` is unconditional in
the builder. No fallback session is used: with two experiments in play there is no way to
tell which one an unrecognised run belongs to. Evaluator-supplied text is sanitized before
logging so a judge's output can't forge log records.

The other feedback paths were checked and are unaffected — `evaluate()` supplies
`session_id` via `TraceConfig`, and `evaluateExisting()` via the required
`RunSchema.session_id`.

New `EvaluateSupportTest` calls the internal helper directly with a mocked
`FeedbackService`. This path had no coverage before.

## Test Plan

- [x] `./gradlew :langsmith-java-core:test` green (422 test classes); `lintKotlin` clean