### PR TITLE
fix(evaluation): link traced runs to examples

### DIFF
--- a/langsmith-java-core/src/main/kotlin/com/langchain/smith/evaluation/EvaluateRunner.kt
+++ b/langsmith-java-core/src/main/kotlin/com/langchain/smith/evaluation/EvaluateRunner.kt
@@ -219,9 +219,7 @@ internal class EvaluateRunner(
                     name = "Target",
                     client = client,
                     projectName = experimentName,
-                    referenceExampleId =
-                        if (params.errorHandling == EvaluateErrorHandling.LOG) example.id()
-                        else null,
+                    referenceExampleId = example.id(),
                     sessionId = sessionId,
                     metadata = runMetadata,
                     tracingEnabled = true,

--- a/langsmith-java-core/src/test/kotlin/com/langchain/smith/evaluation/EvaluateRunnerTest.kt
+++ b/langsmith-java-core/src/test/kotlin/com/langchain/smith/evaluation/EvaluateRunnerTest.kt
@@ -64,6 +64,7 @@ internal class EvaluateRunnerTest {
                     }
                 )
                 .experimentName("test-experiment")
+                .errorHandling(EvaluateErrorHandling.IGNORE)
                 .build()
 
         val results = evaluate(client, { mapOf("answer" to "Paris") }, params)


### PR DESCRIPTION
closes: #210 
## Summary

- Always link traced evaluation runs to their source dataset example.
- Add regression coverage for successful evaluations using `EvaluateErrorHandling.IGNORE`.

## Problem

`referenceExampleId` was set only when `EvaluateErrorHandling.LOG` was selected. Successful traced runs created with other error-handling modes were therefore not associated with their dataset example.

## Testing

- `git diff --check`
- Focused `EvaluateRunnerTest` run was attempted but exceeded the local execution timeout.