### PR TITLE
fix(evaluation): retain runs after target errors

### DIFF
--- a/langsmith-java-core/src/main/kotlin/com/langchain/smith/evaluation/EvaluateRunner.kt
+++ b/langsmith-java-core/src/main/kotlin/com/langchain/smith/evaluation/EvaluateRunner.kt
@@ -209,7 +209,8 @@ internal class EvaluateRunner(
     ): RunIngest? {
         var runTree: RunTree? = null
         val wrappedTarget: (Map<String, Any?>) -> Any? = { exampleInputs ->
-            target(exampleInputs).also { runTree = getCurrentRunTree() }
+            runTree = getCurrentRunTree()
+            target(exampleInputs)
         }
 
         val traced =

--- a/langsmith-java-core/src/main/kotlin/com/langchain/smith/evaluation/EvaluateRunner.kt
+++ b/langsmith-java-core/src/main/kotlin/com/langchain/smith/evaluation/EvaluateRunner.kt
@@ -219,9 +219,7 @@ internal class EvaluateRunner(
                     name = "Target",
                     client = client,
                     projectName = experimentName,
-                    referenceExampleId =
-                        if (params.errorHandling == EvaluateErrorHandling.LOG) example.id()
-                        else null,
+                    referenceExampleId = example.id(),
                     sessionId = sessionId,
                     metadata = runMetadata,
                     tracingEnabled = true,

--- a/langsmith-java-core/src/test/kotlin/com/langchain/smith/evaluation/EvaluateRunnerTest.kt
+++ b/langsmith-java-core/src/test/kotlin/com/langchain/smith/evaluation/EvaluateRunnerTest.kt
@@ -64,6 +64,7 @@ internal class EvaluateRunnerTest {
                     }
                 )
                 .experimentName("test-experiment")
+                .errorHandling(EvaluateErrorHandling.IGNORE)
                 .build()
 
         val results = evaluate(client, { mapOf("answer" to "Paris") }, params)

--- a/langsmith-java-core/src/test/kotlin/com/langchain/smith/evaluation/EvaluateRunnerTest.kt
+++ b/langsmith-java-core/src/test/kotlin/com/langchain/smith/evaluation/EvaluateRunnerTest.kt
@@ -89,6 +89,42 @@ internal class EvaluateRunnerTest {
     }
 
     @Test
+    fun evaluate_logsTargetErrorsAndIncludesTheirRuns() {
+        val runService = mock<RunService>()
+        val sessionService = mock<SessionService>()
+        val feedbackService = mock<FeedbackService>()
+
+        whenever(sessionService.create(any<SessionCreateParams>())).doReturn(sampleSession())
+        whenever(feedbackService.create(any<FeedbackCreateSchema>())).doReturn(sampleFeedback())
+        whenever(runService.create(any<RunIngest>())).doReturn(RunCreateResponse.builder().build())
+        whenever(runService.update(any<RunUpdateParams>())).doAnswer {}
+
+        val client =
+            mock<LangsmithClient> {
+                on { runs() } doReturn runService
+                on { sessions() } doReturn sessionService
+                on { feedback() } doReturn feedbackService
+            }
+
+        val params =
+            EvaluateParams.builder()
+                .data(listOf(sampleExample()))
+                .addEvaluator(
+                    runEvaluator { _: RunIngest, _: Example? ->
+                        EvaluationResult(key = "match", score = 0)
+                    }
+                )
+                .experimentName("target-error-test")
+                .build()
+
+        val results = evaluate(client, { _ -> throw IllegalStateException("target failed") }, params)
+
+        val run = results.rows.single().run
+        assertThat(run.referenceExampleId()).contains(exampleId)
+        assertThat(run.error()).contains("target failed")
+    }
+
+    @Test
     fun evaluate_runsExamplesInParallelWhenMaxConcurrencyIsSet() {
         val runService = mock<RunService>()
         val sessionService = mock<SessionService>()


### PR DESCRIPTION
Fixes #211

## Summary

- Capture the traced run before calling the evaluation target.
- Retain error-bearing runs when a target throws under `EvaluateErrorHandling.LOG`.
- Add regression coverage for this path.

## Testing

- `git diff --check`
- Focused `EvaluateRunnerTest` was attempted but exceeded the local execution timeout.