### PR TITLE
fix: remediate Apache HTTP and Log4j advisories

### DIFF
--- a/langsmith-java-core/build.gradle.kts
+++ b/langsmith-java-core/build.gradle.kts
@@ -50,8 +50,8 @@ dependencies {
     implementation("com.fasterxml.jackson.datatype:jackson-datatype-jsr310:$jacksonVersion")
     implementation("com.fasterxml.jackson.module:jackson-module-kotlin:$jacksonVersion")
     implementation("com.github.luben:zstd-jni:1.5.7-7")
-    implementation("org.apache.httpcomponents.core5:httpcore5:5.2.4")
-    implementation("org.apache.httpcomponents.client5:httpclient5:5.3.1")
+    implementation("org.apache.httpcomponents.core5:httpcore5:5.4.3")
+    implementation("org.apache.httpcomponents.client5:httpclient5:5.6.4")
 
     // OpenTelemetry dependencies
     api("io.opentelemetry:opentelemetry-api:1.62.0")
@@ -86,7 +86,8 @@ dependencies {
         testImplementation("org.bouncycastle:bcpg-jdk18on:1.84")
         testImplementation("org.bouncycastle:bcpkix-jdk18on:1.84")
         testImplementation("org.bouncycastle:bcprov-jdk18on:1.84")
-        testImplementation("org.apache.logging.log4j:log4j-core:2.25.4")
+        testImplementation("org.apache.logging.log4j:log4j-api:2.25.5")
+        testImplementation("org.apache.logging.log4j:log4j-core:2.25.5")
         testImplementation("org.apache.opennlp:opennlp-tools") { version { require("2.5.9") } }
         testImplementation("com.github.jknack:handlebars") { version { require("4.5.2") } }
         testImplementation("org.codehaus.plexus:plexus-utils:4.0.3")

--- a/langsmith-java-example/build.gradle.kts
+++ b/langsmith-java-example/build.gradle.kts
@@ -14,6 +14,7 @@ configurations.configureEach {
     resolutionStrategy.force(
         "ch.qos.logback:logback-classic:1.5.35",
         "ch.qos.logback:logback-core:1.5.35",
+        "org.apache.logging.log4j:log4j-api:2.25.5",
     )
 }
 

--- a/langsmith-java-proguard-test/build.gradle.kts
+++ b/langsmith-java-proguard-test/build.gradle.kts
@@ -8,10 +8,10 @@ buildscript {
         resolutionStrategy {
             // CVE-2025-67030: remove once Shadow safely resolves plexus-utils >= 4.0.3.
             force("org.codehaus.plexus:plexus-utils:4.0.3")
-            // CVE-2025-68161 and CVE-2026-34477/34478/34480: remove once the build
-            // plugins resolve Log4j >= 2.25.4.
-            force("org.apache.logging.log4j:log4j-api:2.25.4")
-            force("org.apache.logging.log4j:log4j-core:2.25.4")
+            // CVE-2025-68161, CVE-2026-34477/34478/34480, and CVE-2026-49844:
+            // remove once the build plugins resolve Log4j >= 2.25.5.
+            force("org.apache.logging.log4j:log4j-api:2.25.5")
+            force("org.apache.logging.log4j:log4j-core:2.25.5")
         }
     }
 


### PR DESCRIPTION
## Summary

- upgrade Apache HttpClient to 5.6.4 for CVE-2026-64607
- upgrade Apache HttpCore/HTTP2 to 5.4.3 for CVE-2026-54399 and CVE-2026-54428
- constrain Log4j API/Core to 2.25.5 for CVE-2026-49844
- keep changes scoped to the affected runtime, example, and ProGuard test configurations

## Validation

- resolved `httpclient5` at 5.6.4
- resolved `httpcore5` and `httpcore5-h2` at 5.4.3
- resolved example `log4j-api` at 2.25.5
- `git diff --check`

Full Kotlin compilation could not complete in the Fleet sandbox because the compiler exceeded the sandbox memory limit; CI remains authoritative.