### PR TITLE
docs: fix stale javadoc link in README badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 <!-- x-release-please-start-version -->
 
 [![Maven Central](https://img.shields.io/maven-central/v/com.langchain.smith/langsmith-java)](https://central.sonatype.com/artifact/com.langchain.smith/langsmith-java/0.1.0-beta.22)
-[![javadoc](https://javadoc.io/badge2/com.langchain.smith/langsmith-java/0.1.0-beta.22/javadoc.svg)](https://javadoc.io/doc/com.langchain.smith/langsmith-java/0.1.0-beta.18)
+[![javadoc](https://javadoc.io/badge2/com.langchain.smith/langsmith-java/0.1.0-beta.22/javadoc.svg)](https://javadoc.io/doc/com.langchain.smith/langsmith-java/0.1.0-beta.22)
 
 <!-- x-release-please-end -->
 


### PR DESCRIPTION
The javadoc badge in the README was showing the correct version (0.1.0-beta.22)
but the link behind it still pointed to 0.1.0-beta.18, so clicking the badge
took users to outdated Javadocs.

This PR updates the link target to match the badge version.