### PR TITLE
evaluation: add evaluateComparativeAsync() overloads

### DIFF
--- a/langsmith-java-core/src/main/kotlin/com/langchain/smith/evaluation/Evaluate.kt
+++ b/langsmith-java-core/src/main/kotlin/com/langchain/smith/evaluation/Evaluate.kt
@@ -110,6 +110,33 @@ fun evaluateExistingAsync(
     )
 
 /**
+ * Runs pairwise evaluators asynchronously. Equivalent to calling [evaluateComparative] on a
+ * background thread — use [CompletableFuture.join] or [CompletableFuture.get] when the results are
+ * needed.
+ */
+fun evaluateComparativeAsync(
+    client: LangsmithClient,
+    experiments: Pair<String, String>,
+    params: EvaluateComparativeParams,
+): CompletableFuture<ComparativeExperimentResults> =
+    CompletableFuture.supplyAsync(
+        { EvaluateComparativeRunner(client, experiments, params).run() },
+        evaluateExecutor,
+    )
+
+/** Async overload accepting experiment ids as a list. */
+fun evaluateComparativeAsync(
+    client: LangsmithClient,
+    experiments: List<String>,
+    params: EvaluateComparativeParams,
+): CompletableFuture<ComparativeExperimentResults> {
+    require(experiments.size == 2) {
+        "Comparative evaluation requires exactly 2 experiments, got ${experiments.size}"
+    }
+    return evaluateComparativeAsync(client, experiments[0] to experiments[1], params)
+}
+
+/**
  * Compares two existing experiments with pairwise evaluators. Mirrors Python `evaluate_comparative`
  * and `evaluate((experiment_a, experiment_b), ...)`.
  */


### PR DESCRIPTION
Every blocking evaluate function in this SDK has an async counterpart:

- evaluate()         → evaluateAsync()
- evaluateExisting() → evaluateExistingAsync()
- evaluateComparative() → ❌ missing

Comparative evaluation is one of the heavier operations — it fetches
runs from two experiments and applies pairwise evaluators concurrently —
so a non-blocking variant is especially useful for callers that don't
want to block their thread.

This PR adds:
- evaluateComparativeAsync(client, Pair<String, String>, params)
- evaluateComparativeAsync(client, List<String>, params)

Both delegate to EvaluateComparativeRunner on the shared
evaluateExecutor, exactly matching the pattern used by the other
async helpers.