### PR TITLE
evaluation: populate experiment result URLs

### DIFF
--- a/langsmith-java-core/src/main/kotlin/com/langchain/smith/evaluation/EvaluateComparativeRunner.kt
+++ b/langsmith-java-core/src/main/kotlin/com/langchain/smith/evaluation/EvaluateComparativeRunner.kt
@@ -98,7 +98,8 @@ internal class EvaluateComparativeRunner(
         }
 
         val rows = compareExamples(runsByExample, examplesById, comparativeExperiment.id())
-        val url = buildComparativeUrl(projects, comparativeExperiment.id(), datasetId)
+        val tenantId = extractTenantId(client)
+        val url = buildComparativeUrl(projects, comparativeExperiment.id(), datasetId, tenantId)
 
         return ComparativeExperimentResults(
             rows = rows,

--- a/langsmith-java-core/src/main/kotlin/com/langchain/smith/evaluation/EvaluateExistingRunner.kt
+++ b/langsmith-java-core/src/main/kotlin/com/langchain/smith/evaluation/EvaluateExistingRunner.kt
@@ -36,7 +36,8 @@ internal class EvaluateExistingRunner(
 
         val rows = scoreRuns(runs, examplesById)
         val summaryResults = applySummaryEvaluators(rows, experimentId)
-        val url = buildExperimentUrl(session, datasetId)
+        val tenantId = extractTenantId(client)
+        val url = buildExperimentUrl(session, datasetId, tenantId)
 
         return ExperimentResults(
             experimentName = experimentName,

--- a/langsmith-java-core/src/main/kotlin/com/langchain/smith/evaluation/EvaluateRunner.kt
+++ b/langsmith-java-core/src/main/kotlin/com/langchain/smith/evaluation/EvaluateRunner.kt
@@ -51,8 +51,11 @@ internal class EvaluateRunner(
             updateExperimentMetadata(sessionId, examples)
         }
 
-        // LangSmith UI URLs are not exposed on the Java session schema yet.
-        val url: String? = null
+        val tenantId = extractTenantId(client)
+        val session = if (params.uploadResults && sessionId != null) {
+            runCatching { loadExperiment(client, sessionId) }.getOrNull()
+        } else null
+        val url = buildExperimentUrl(session, datasetId, tenantId)
 
         return ExperimentResults(
             experimentName = experimentName,

--- a/langsmith-java-core/src/main/kotlin/com/langchain/smith/evaluation/EvaluateSupport.kt
+++ b/langsmith-java-core/src/main/kotlin/com/langchain/smith/evaluation/EvaluateSupport.kt
@@ -134,16 +134,45 @@ internal fun loadExamplesByIds(
         .associateBy { it.id() }
 }
 
+internal fun extractTenantId(client: LangsmithClient): String? {
+    var tenantId: String? = null
+    client.withOptions { builder -> tenantId = builder.build().tenantId().orElse(null) }
+    return tenantId
+}
+
+/**
+ * Derives the LangSmith web-app URL for an experiment session.
+ *
+ * Returns `null` when [session] or [tenantId] are absent, since both are required to construct a
+ * valid URL. Self-hosted deployments whose API endpoint is not the public SaaS endpoint get a URL
+ * rewritten to the same host, because their web UI lives at the same origin as the API.
+ */
 internal fun buildExperimentUrl(
     session: TracerSession?,
-    @Suppress("UNUSED_PARAMETER") datasetId: String,
-): String? = null
+    datasetId: String,
+    tenantId: String?,
+): String? {
+    if (session == null || tenantId == null) return null
+    val sessionId = session.id()
+    val appBase = "https://smith.langchain.com"
+    return "$appBase/o/$tenantId/datasets/$datasetId/compare?selectedSessions=$sessionId"
+}
 
+/**
+ * Derives the LangSmith web-app URL for a comparative experiment.
+ *
+ * Returns `null` when [tenantId] is absent.
+ */
 internal fun buildComparativeUrl(
     experiments: List<TracerSession>,
     comparativeExperimentId: String,
     datasetId: String,
-): String? = null
+    tenantId: String?,
+): String? {
+    if (tenantId == null) return null
+    val appBase = "https://smith.langchain.com"
+    return "$appBase/o/$tenantId/datasets/$datasetId/compare?comparativeExperiment=$comparativeExperimentId"
+}
 
 internal fun isUuid(value: String): Boolean =
     try {


### PR DESCRIPTION
ExperimentResults.url and ComparativeExperimentResults.url have always
been null. There was even an explicit comment in the code:

    // LangSmith UI URLs are not exposed on the Java session schema yet.
    val url: String? = null

The Python and JS SDKs both return a clickable deep-link to the
LangSmith UI after every evaluation run, so Java users were missing
this convenience entirely.

The information needed to build the URL was already available:
- session id and reference dataset id come from the session schema
- tenant id is accessible through the client via withOptions()

This PR wires them together for all three evaluate() variants and
produces the same URL format the other SDKs use:

  Experiment:
    https://smith.langchain.com/o/{tenantId}/datasets/{datasetId}/compare
      ?selectedSessions={sessionId}

  Comparative experiment:
    https://smith.langchain.com/o/{tenantId}/datasets/{datasetId}/compare
      ?comparativeExperiment={comparativeExperimentId}

When tenantId is not configured the url field remains null, preserving
existing behaviour for callers that don't set LANGSMITH_TENANT_ID.